### PR TITLE
CMAKE_BUILD_TYPE support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 /.vscode
 /build
-/generated_src
+/gen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 
 project(cloxx)
 
-file(GLOB CLOXX_SOURCES src/*.cpp generated_src/*.cpp)
+file(GLOB CLOXX_SOURCES src/*.cpp gen/*.cpp)
 add_executable(cloxx ${CLOXX_SOURCES})
-target_include_directories(cloxx PRIVATE src generated_src)
+target_include_directories(cloxx PRIVATE src gen)
 set_target_properties(cloxx PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ __cloxx__ implements the following features:
 ## How to build cloxx
 
 ```
+$ script/bootstrap.sh
 $ script/configure.sh
 $ script/build.sh
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,19 @@ __cloxx__ implements the following features:
 
 ## How to build cloxx
 
-```
+Once you've cloned the repo, run bootstrapping script to setup the repo, e.g., generate AST files, etc.:
+```bash
 $ script/bootstrap.sh
-$ script/configure.sh
+```
+
+Then configure build files. By default, it will generate Posix-compatible makefiles.
+```bash
+$ script/configure.sh # pass "--debug" if that's what you want
+$ script/build.sh
+```
+
+Finally, build the cloxx interpreter. This will create cloxx executable under `build` directory.
+```bash
 $ script/build.sh
 ```
 

--- a/scripts/apply-format-all.sh
+++ b/scripts/apply-format-all.sh
@@ -2,4 +2,4 @@
 
 scriptDir="$(cd "$(dirname "$0")" && pwd -P)"
 find "src" -type f -print | xargs "${scriptDir}"/apply-format.sh
-find "generated_src" -type f -print | xargs "${scriptDir}"/apply-format.sh
+find "gen" -type f -print | xargs "${scriptDir}"/apply-format.sh

--- a/scripts/configure-debug.sh
+++ b/scripts/configure-debug.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-$SCRIPT_DIR/configure.sh -r
+$SCRIPT_DIR/configure.sh --debug $1

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -1,10 +1,49 @@
 #!/bin/bash
 
+#set -e
+
 PROJECT=$(git rev-parse --show-toplevel)
 BUILD="$PROJECT/build"
-if [ "$1" == "-r" ]; then
+
+BUILD_TYPE_FILE_PATH="$BUILD/BUILD_TYPE"
+BUILD_TYPE="Release"
+OLD_BUILD_TYPE=""
+
+CLEAN_FORCED=no
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--debug)
+      BUILD_TYPE="Debug"
+      shift
+      ;;
+    -c|--clean)
+      CLEAN_FORCED=yes
+      shift
+      ;;
+    *) # unknown option - skip
+      shift
+      ;;
+  esac
+done
+
+
+buildtype_mismatch() {
+  if [ -f "$BUILD_TYPE_FILE_PATH" ]; then
+    OLD_BUILD_TYPE=`cat $BUILD_TYPE_FILE_PATH`
+    if [ "$OLD_BUILD_TYPE" == $BUILD_TYPE ]; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
+if [ $CLEAN_FORCED == "yes" ] || buildtype_mismatch ; then
   rm -rf "$BUILD"
 fi
-mkdir -p "$BUILD" && pushd "$BUILD" > /dev/null && cmake  -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .. && popd > /dev/null
 
-"$PROJECT/scripts/gen-ast.sh"
+# generate Makefiles
+mkdir -p "$BUILD" && pushd "$BUILD" && cmake  -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G "Unix Makefiles" .. && popd > /dev/null
+
+# store current build type
+printf "$BUILD_TYPE" > "$BUILD_TYPE_FILE_PATH"

--- a/scripts/gen-ast.sh
+++ b/scripts/gen-ast.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PROJECT=$(git rev-parse --show-toplevel)
-GENPATH="$PROJECT/generated_src/ast"
+GENPATH="$PROJECT/gen/ast"
 
 rm -rf "$GENPATH"
 mkdir -p "$GENPATH"

--- a/tool/gen-ast.py
+++ b/tool/gen-ast.py
@@ -123,7 +123,6 @@ if __name__ == '__main__':
         sys.exit('Usage: ' + __file__ + ' dirpath')
 
     outputDir = sys.argv[1]
-    print(outputDir)
 
     _generateAst(outputDir, ['Token.hpp'], 'Expr', [
         "Assign   : Token name, Expr value",


### PR DESCRIPTION
Changes:

- Make `script/configure.sh` to run CMake with `CMAKE_BUILD_TYPE=Release` by default. `--debug` can be passed to configure Debug build.
- Auto-detect current build type to clean the `build` directory when configured with a different build type.