### PR TITLE
Make explicit call of init() return "this".

### DIFF
--- a/src/LoxFunction.cpp
+++ b/src/LoxFunction.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<LoxObject> LoxFunction::call(std::vector<std::shared_ptr<LoxObje
 
     if (_isInitializer) {
         _executor(env, _body);
-        return makeLoxNil();
+        return _closure->getAt(0, "this");
     }
 
     return _executor(env, _body);

--- a/tool/run-test.py
+++ b/tool/run-test.py
@@ -329,15 +329,9 @@ def _defineTestSuites():
         noJavaLimits
     )
 
-    cloxxTests = _merge_dicts(
-        # cloxx behaves pretty much the same as jlox
-        jloxTests,
+    # cloxx behaves like jlox
+    _allSuites["cloxx"] = Suite("cloxx", jloxTests)
 
-        # except, cloxx's init always returns nil
-        { "test/constructor/call_init_explicitly.lox": "skip"}
-    )
-
-    _allSuites["cloxx"] = Suite("cloxx", cloxxTests)
     # more suites can go here...
 
 


### PR DESCRIPTION
Previously, __cloxx__'s initializer (`init()`)  would return `nil` when they are explicitly called.
This PR makes initializers to return `this`.

Now __cloxx__ passes all [__jlox__ test suite](https://github.com/munificent/craftinginterpreters/blob/6c2ea6f7192910053a78832f0cc34ad56b17ce7c/tool/bin/test.dart#L592-L597), and I can claim __cloxx__ is 100% compatible with __jlox__.