### PR TITLE
Store resolved variable/identifier depth directly in AST

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -166,8 +166,8 @@ void Interpreter::visit(AssignExpr const& expr)
     auto value = evaluate(*expr.value);
     LOX_ASSERT(value);
 
-    if (expr.depth >= 0) {
-        _environment->assignAt(expr.depth, expr.name.lexeme, value);
+    if (expr.resolvedDepth >= 0) {
+        _environment->assignAt(expr.resolvedDepth, expr.name.lexeme, value);
     }
     else {
         _globals->assign(expr.name, value);
@@ -327,8 +327,8 @@ void Interpreter::visit(SetExpr const& expr)
 void Interpreter::visit(ThisExpr const& expr)
 {
     std::shared_ptr<LoxObject> object;
-    if (expr.depth >= 0) {
-        object = _environment->getAt(expr.depth, expr.keyword.lexeme);
+    if (expr.resolvedDepth >= 0) {
+        object = _environment->getAt(expr.resolvedDepth, expr.keyword.lexeme);
     }
     else {
         object = _globals->get(expr.keyword);
@@ -341,8 +341,8 @@ void Interpreter::visit(SuperExpr const& expr)
 {
     LOX_ASSERT(expr.keyword.lexeme == "super");
 
-    if (expr.depth >= 0) {
-        auto distance = expr.depth;
+    if (expr.resolvedDepth >= 0) {
+        auto distance = expr.resolvedDepth;
         auto superclass = std::dynamic_pointer_cast<LoxClass>(_environment->getAt(distance, "super"));
         auto instance = std::dynamic_pointer_cast<LoxInstance>(_environment->getAt(distance - 1, "this"));
         if (superclass && instance) {
@@ -377,8 +377,8 @@ void Interpreter::visit(UnaryExpr const& expr)
 void Interpreter::visit(VariableExpr const& expr)
 {
     std::shared_ptr<LoxObject> object;
-    if (expr.depth >= 0) {
-        object = _environment->getAt(expr.depth, expr.name.lexeme);
+    if (expr.resolvedDepth >= 0) {
+        object = _environment->getAt(expr.resolvedDepth, expr.name.lexeme);
     }
     else {
         object = _globals->get(expr.name);

--- a/src/Interpreter.hpp
+++ b/src/Interpreter.hpp
@@ -21,7 +21,6 @@ public:
     Interpreter(Lox* lox, GarbageCollector* gc);
 
     void interpret(std::vector<std::shared_ptr<Stmt>> const& stmts);
-    void resolve(Expr const& expr, size_t depth);
 
 private:
     // StmtVisitor
@@ -54,8 +53,6 @@ private:
 
     std::shared_ptr<LoxObject> evaluate(Expr const& expr);
 
-    std::shared_ptr<LoxObject> lookUpVariable(Token const& name, Expr const& expr) const;
-
     template <typename OperandType, typename Callback>
     bool matchOperand(std::shared_ptr<LoxObject> const& right, Callback&& callback);
     template <typename OperandType, typename Callback>
@@ -79,8 +76,6 @@ private:
     GarbageCollector* const _gc;
     std::shared_ptr<Environment> _globals;
     std::shared_ptr<Environment> _environment;
-
-    std::map<Expr const*, /*depth*/ size_t> _locals;
 
     std::vector<std::shared_ptr<LoxObject>> _evalResults;
 };

--- a/src/Lox.cpp
+++ b/src/Lox.cpp
@@ -49,7 +49,7 @@ int Lox::run(std::string source)
 
     Interpreter interpreter{this, &gc};
 
-    Resolver resolver{this, &interpreter};
+    Resolver resolver{this};
     resolver.resolve(stmts);
 
     // Stop if there was a resolution error.

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<Stmt> Parser::classDeclaration()
     std::shared_ptr<VariableExpr> superclass;
     if (match(Token::LESS)) {
         consume(Token::IDENTIFIER, "Expect superclass name.");
-        superclass = std::make_shared<VariableExpr>(previous(), /*depth*/ -1);
+        superclass = std::make_shared<VariableExpr>(previous());
     }
 
     consume(Token::LEFT_BRACE, "Expect '{' before class body.");
@@ -287,7 +287,7 @@ std::shared_ptr<Expr> Parser::assignment()
         auto const& value = assignment();
 
         if (auto const var = dynamic_cast<VariableExpr*>(expr.get())) {
-            return std::make_shared<AssignExpr>(var->name, value, /*depth*/ -1);
+            return std::make_shared<AssignExpr>(var->name, value);
         }
 
         if (auto const get = dynamic_cast<GetExpr*>(expr.get())) {
@@ -468,18 +468,18 @@ std::shared_ptr<Expr> Parser::primary()
     }
 
     if (match(Token::IDENTIFIER)) {
-        return std::make_shared<VariableExpr>(previous(), /*depth*/ -1);
+        return std::make_shared<VariableExpr>(previous());
     }
 
     if (match(Token::THIS)) {
-        return std::make_shared<ThisExpr>(previous(), /*depth*/ -1);
+        return std::make_shared<ThisExpr>(previous());
     }
 
     if (match(Token::SUPER)) {
         auto const& keyword = previous();
         consume(Token::DOT, "Expect '.' after 'super'.");
         auto const& method = consume(Token::IDENTIFIER, "Expect superclass method name.");
-        return std::make_shared<SuperExpr>(keyword, method, /*depth*/ -1);
+        return std::make_shared<SuperExpr>(keyword, method);
     }
 
     throw error(peek(), "Expect expression.");

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<Stmt> Parser::classDeclaration()
     std::shared_ptr<VariableExpr> superclass;
     if (match(Token::LESS)) {
         consume(Token::IDENTIFIER, "Expect superclass name.");
-        superclass = std::make_shared<VariableExpr>(previous());
+        superclass = std::make_shared<VariableExpr>(previous(), /*depth*/ -1);
     }
 
     consume(Token::LEFT_BRACE, "Expect '{' before class body.");
@@ -287,7 +287,7 @@ std::shared_ptr<Expr> Parser::assignment()
         auto const& value = assignment();
 
         if (auto const var = dynamic_cast<VariableExpr*>(expr.get())) {
-            return std::make_shared<AssignExpr>(var->name, value);
+            return std::make_shared<AssignExpr>(var->name, value, /*depth*/ -1);
         }
 
         if (auto const get = dynamic_cast<GetExpr*>(expr.get())) {
@@ -468,18 +468,18 @@ std::shared_ptr<Expr> Parser::primary()
     }
 
     if (match(Token::IDENTIFIER)) {
-        return std::make_shared<VariableExpr>(previous());
+        return std::make_shared<VariableExpr>(previous(), /*depth*/ -1);
     }
 
     if (match(Token::THIS)) {
-        return std::make_shared<ThisExpr>(previous());
+        return std::make_shared<ThisExpr>(previous(), /*depth*/ -1);
     }
 
     if (match(Token::SUPER)) {
         auto const& keyword = previous();
         consume(Token::DOT, "Expect '.' after 'super'.");
         auto const& method = consume(Token::IDENTIFIER, "Expect superclass method name.");
-        return std::make_shared<SuperExpr>(keyword, method);
+        return std::make_shared<SuperExpr>(keyword, method, /*depth*/ -1);
     }
 
     throw error(peek(), "Expect expression.");

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -200,7 +200,7 @@ void Resolver::visit(ClassStmt const& stmt)
 void Resolver::visit(AssignExpr const& expr)
 {
     resolve(*expr.value);
-    const_cast<AssignExpr&>(expr).depth = resolveLocal(expr.name);
+    const_cast<AssignExpr&>(expr).resolvedDepth = resolveLocal(expr.name);
 }
 
 void Resolver::visit(BinaryExpr const& expr)
@@ -250,7 +250,7 @@ void Resolver::visit(ThisExpr const& expr)
         _lox->error(expr.keyword, "Can't use 'this' outside of a class.");
     }
 
-    const_cast<ThisExpr&>(expr).depth = resolveLocal(expr.keyword);
+    const_cast<ThisExpr&>(expr).resolvedDepth = resolveLocal(expr.keyword);
 }
 
 void Resolver::visit(SuperExpr const& expr)
@@ -262,7 +262,7 @@ void Resolver::visit(SuperExpr const& expr)
         _lox->error(expr.keyword, "Can't use 'super' in a class with no superclass.");
     }
 
-    const_cast<SuperExpr&>(expr).depth = resolveLocal(expr.keyword);
+    const_cast<SuperExpr&>(expr).resolvedDepth = resolveLocal(expr.keyword);
 }
 
 void Resolver::visit(UnaryExpr const& expr)
@@ -282,7 +282,7 @@ void Resolver::visit(VariableExpr const& expr)
         }
     }
 
-    const_cast<VariableExpr&>(expr).depth = resolveLocal(expr.name);
+    const_cast<VariableExpr&>(expr).resolvedDepth = resolveLocal(expr.name);
 }
 
 } // namespace cloxx

--- a/src/Resolver.hpp
+++ b/src/Resolver.hpp
@@ -12,7 +12,7 @@ class Interpreter;
 
 class Resolver : StmtVisitor, ExprVisitor {
 public:
-    explicit Resolver(Lox* lox, Interpreter* interpreter);
+    explicit Resolver(Lox* lox);
 
     void resolve(std::vector<std::shared_ptr<Stmt>> const& stmts);
 
@@ -40,7 +40,7 @@ private:
     void declare(Token const& name);
     void define(Token const& name);
 
-    void resolveLocal(Expr const& expr, Token const& name);
+    int resolveLocal(Token const& name);
     void resolveFunction(FunStmt const& stmt, FunctionType functionType);
 
     // StmtVisitor
@@ -70,7 +70,6 @@ private:
 
 private:
     Lox* const _lox;
-    Interpreter* const _interpreter;
 
     std::vector<Scope> _scopes;
     FunctionType _currentFunction = FunctionType::NONE;

--- a/tool/gen-ast.py
+++ b/tool/gen-ast.py
@@ -4,6 +4,8 @@ import os.path
 import sys
 
 def _makeCtorParamType(type):
+    if type == 'int':
+        return type
     if type == 'Token':
         return type + ' const&'
     if type.startswith('List<'):
@@ -14,6 +16,8 @@ def _makeCtorParamType(type):
     return 'std::shared_ptr<' + type + '> const&'
 
 def _makeMemVarType(type):
+    if type == 'int':
+        return type
     if type == 'Token':
         return type + ' const'
     if type.startswith('List<'):
@@ -125,7 +129,7 @@ if __name__ == '__main__':
     outputDir = sys.argv[1]
 
     _generateAst(outputDir, ['Token.hpp'], 'Expr', [
-        "Assign   : Token name, Expr value",
+        "Assign   : Token name, Expr value, int depth",
         "Binary   : Token op, Expr left, Expr right",
         "Call     : Expr callee, Token paren, List<Expr> args",
         "Get      : Expr object, Token name",
@@ -133,10 +137,10 @@ if __name__ == '__main__':
         "Literal  : LoxObject value",
         "Logical  : Token op, Expr left, Expr right",
         "Set      : Expr object, Token name, Expr value",
-        "This     : Token keyword",
-        "Super    : Token keyword, Token method",
+        "This     : Token keyword, int depth",
+        "Super    : Token keyword, Token method, int depth",
         "Unary    : Token op, Expr right",
-        "Variable : Token name",
+        "Variable : Token name, int depth",
     ])
 
     _generateAst(outputDir, ['Token.hpp', 'Expr.hpp'], 'Stmt', [


### PR DESCRIPTION
In the book, `Resolver` resolves depth of identifiers (variables, `this` and `super`) and store them in a map (`_locals`) in `Interpreter`. Then `Interpreter` _looks up_ the depth of each AST node via the map when it evaluate or assign the identifiers. This isn't really necessary if we can store the depth directly in AST nodes.