### PR TITLE
Remove print statement

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -1,7 +1,5 @@
 #include "Interpreter.hpp"
 
-#include <iostream> // for print statement
-
 #include "Assert.hpp"
 #include "GC.hpp"
 #include "Lox.hpp"
@@ -98,13 +96,6 @@ void Interpreter::visit(ReturnStmt const& stmt)
     }
 
     throw returnValue;
-}
-
-void Interpreter::visit(PrintStmt const& stmt)
-{
-    auto value = evaluate(stmt.expr);
-    LOX_ASSERT(value);
-    std::cout << value->toString() << '\n';
 }
 
 void Interpreter::visit(VarStmt const& stmt)

--- a/src/Interpreter.hpp
+++ b/src/Interpreter.hpp
@@ -29,7 +29,6 @@ private:
     void visit(IfStmt const& stmt) override;
     void visit(WhileStmt const& stmt) override;
     void visit(ReturnStmt const& stmt) override;
-    void visit(PrintStmt const& stmt) override;
     void visit(VarStmt const& stmt) override;
     void visit(FunStmt const& stmt) override;
     void visit(ClassStmt const& stmt) override;

--- a/src/Lox.cpp
+++ b/src/Lox.cpp
@@ -19,6 +19,10 @@ namespace {
 void defineBuiltins(std::shared_ptr<Environment> const& env)
 {
     LOX_ASSERT(env);
+    env->define("print", std::make_shared<LoxNativeFunction>(1, [](auto& args) {
+                    std::cout << args[0]->toString() << '\n';
+                    return makeLoxNil();
+                }));
     env->define("clock", std::make_shared<LoxNativeFunction>(0, [](auto& /*args*/) {
                     auto duration = std::chrono::steady_clock::now().time_since_epoch();
                     auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -138,9 +138,6 @@ Stmt Parser::statement()
     if (match(Token::RETURN)) {
         return returnStatement();
     }
-    if (match(Token::PRINT)) {
-        return printStatement();
-    }
     if (match(Token::LEFT_BRACE)) {
         return makeBlockStmt(block());
     }
@@ -245,13 +242,6 @@ Stmt Parser::returnStatement()
     }
 
     return makeReturnStmt(keyword, expr);
-}
-
-Stmt Parser::printStatement()
-{
-    auto const value = expression();
-    consume(Token::SEMICOLON, "Expect ';' after value.");
-    return makePrintStmt(value);
 }
 
 Stmt Parser::expressionStatement()
@@ -565,7 +555,6 @@ void Parser::synchronize()
         case Token::FOR:
         case Token::IF:
         case Token::WHILE:
-        case Token::PRINT:
         case Token::RETURN:
             return;
         default:

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -27,7 +27,6 @@ private:
     Stmt whileStatement();
     Stmt forStatement();
     Stmt returnStatement();
-    Stmt printStatement();
     Stmt expressionStatement();
     std::vector<Stmt> block();
     Expr expression();

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -130,11 +130,6 @@ void Resolver::visit(ReturnStmt const& stmt)
     }
 }
 
-void Resolver::visit(PrintStmt const& stmt)
-{
-    resolve(stmt.expr);
-}
-
 void Resolver::visit(VarStmt const& stmt)
 {
     declare(stmt.name);

--- a/src/Resolver.hpp
+++ b/src/Resolver.hpp
@@ -49,7 +49,6 @@ private:
     void visit(IfStmt const& stmt) override;
     void visit(WhileStmt const& stmt) override;
     void visit(ReturnStmt const& stmt) override;
-    void visit(PrintStmt const& stmt) override;
     void visit(VarStmt const& stmt) override;
     void visit(FunStmt const& stmt) override;
     void visit(ClassStmt const& stmt) override;

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -20,10 +20,10 @@ bool isAlphaNumeric(char c)
 } // namespace
 
 std::map<std::string, Token::Type> const Scanner::_keywords = {
-    {"and", Token::AND},   {"class", Token::CLASS}, {"else", Token::ELSE},     {"false", Token::FALSE},
-    {"for", Token::FOR},   {"fun", Token::FUN},     {"if", Token::IF},         {"nil", Token::NIL},
-    {"or", Token::OR},     {"print", Token::PRINT}, {"return", Token::RETURN}, {"super", Token::SUPER},
-    {"this", Token::THIS}, {"true", Token::TRUE},   {"var", Token::VAR},       {"while", Token::WHILE},
+    {"and", Token::AND},   {"class", Token::CLASS},   {"else", Token::ELSE},   {"false", Token::FALSE},
+    {"for", Token::FOR},   {"fun", Token::FUN},       {"if", Token::IF},       {"nil", Token::NIL},
+    {"or", Token::OR},     {"return", Token::RETURN}, {"super", Token::SUPER}, {"this", Token::THIS},
+    {"true", Token::TRUE}, {"var", Token::VAR},       {"while", Token::WHILE},
 };
 
 Scanner::Scanner(Lox* const lox, std::string source) : _lox{lox}, _source{std::move(source)}

--- a/src/Token.cpp
+++ b/src/Token.cpp
@@ -51,7 +51,6 @@ char const* getTokenName(Token::Type tokenType)
         LOX_TOKEN_NAME_CASE(IF);
         LOX_TOKEN_NAME_CASE(NIL);
         LOX_TOKEN_NAME_CASE(OR);
-        LOX_TOKEN_NAME_CASE(PRINT);
         LOX_TOKEN_NAME_CASE(RETURN);
         LOX_TOKEN_NAME_CASE(SUPER);
         LOX_TOKEN_NAME_CASE(THIS);

--- a/src/Token.hpp
+++ b/src/Token.hpp
@@ -48,7 +48,6 @@ struct Token {
         IF,
         NIL,
         OR,
-        PRINT,
         RETURN,
         SUPER,
         THIS,

--- a/test/assignment/associativity.lox
+++ b/test/assignment/associativity.lox
@@ -4,6 +4,6 @@ var c = "c";
 
 // Assignment is right-associative.
 a = b = c;
-print a; // expect: c
-print b; // expect: c
-print c; // expect: c
+print(a); // expect: c
+print(b); // expect: c
+print(c); // expect: c

--- a/test/assignment/global.lox
+++ b/test/assignment/global.lox
@@ -1,8 +1,8 @@
 var a = "before";
-print a; // expect: before
+print(a); // expect: before
 
 a = "after";
-print a; // expect: after
+print(a); // expect: after
 
-print a = "arg"; // expect: arg
-print a; // expect: arg
+print(a = "arg"); // expect: arg
+print(a); // expect: arg

--- a/test/assignment/local.lox
+++ b/test/assignment/local.lox
@@ -1,10 +1,10 @@
 {
   var a = "before";
-  print a; // expect: before
+  print(a); // expect: before
 
   a = "after";
-  print a; // expect: after
+  print(a); // expect: after
 
-  print a = "arg"; // expect: arg
-  print a; // expect: arg
+  print(a = "arg"); // expect: arg
+  print(a); // expect: arg
 }

--- a/test/assignment/syntax.lox
+++ b/test/assignment/syntax.lox
@@ -1,5 +1,5 @@
 // Assignment on RHS of variable.
 var a = "before";
 var c = a = "var";
-print a; // expect: var
-print c; // expect: var
+print(a); // expect: var
+print(c); // expect: var

--- a/test/benchmark/binary_trees.lox
+++ b/test/benchmark/binary_trees.lox
@@ -28,10 +28,10 @@ var stretchDepth = maxDepth + 1;
 
 var start = clock();
 
-print "stretch tree of depth:";
-print stretchDepth;
-print "check:";
-print Tree(0, stretchDepth).check();
+print("stretch tree of depth:");
+print(stretchDepth);
+print("check:");
+print(Tree(0, stretchDepth).check());
 
 var longLivedTree = Tree(0, maxDepth);
 
@@ -52,20 +52,20 @@ while (depth < stretchDepth) {
     i = i + 1;
   }
 
-  print "num trees:";
-  print iterations * 2;
-  print "depth:";
-  print depth;
-  print "check:";
-  print check;
+  print("num trees:");
+  print(iterations * 2);
+  print("depth:");
+  print(depth);
+  print("check:");
+  print(check);
 
   iterations = iterations / 4;
   depth = depth + 2;
 }
 
-print "long lived tree of depth:";
-print maxDepth;
-print "check:";
-print longLivedTree.check();
-print "elapsed:";
-print clock() - start;
+print("long lived tree of depth:");
+print(maxDepth);
+print("check:");
+print(longLivedTree.check());
+print("elapsed:");
+print(clock() - start);

--- a/test/benchmark/equality.lox
+++ b/test/benchmark/equality.lox
@@ -26,9 +26,9 @@ while (i < 10000000) {
 }
 
 var elapsed = clock() - start;
-print "loop";
-print loopTime;
-print "elapsed";
-print elapsed;
-print "equals";
-print elapsed - loopTime;
+print("loop");
+print(loopTime);
+print("elapsed");
+print(elapsed);
+print("equals");
+print(elapsed - loopTime);

--- a/test/benchmark/fib.lox
+++ b/test/benchmark/fib.lox
@@ -4,5 +4,5 @@ fun fib(n) {
 }
 
 var start = clock();
-print fib(35) == 9227465;
-print clock() - start;
+print(fib(35) == 9227465);
+print(clock() - start);

--- a/test/benchmark/instantiation.lox
+++ b/test/benchmark/instantiation.lox
@@ -40,4 +40,4 @@ while (i < 500000) {
   i = i + 1;
 }
 
-print clock() - start;
+print(clock() - start);

--- a/test/benchmark/invocation.lox
+++ b/test/benchmark/invocation.lox
@@ -70,4 +70,4 @@ while (i < 500000) {
   i = i + 1;
 }
 
-print clock() - start;
+print(clock() - start);

--- a/test/benchmark/method_call.lox
+++ b/test/benchmark/method_call.lox
@@ -47,7 +47,7 @@ for (var i = 0; i < n; i = i + 1) {
   val = toggle.activate().value();
 }
 
-print toggle.value();
+print(toggle.value());
 
 val = true;
 var ntoggle = NthToggle(val, 3);
@@ -65,5 +65,5 @@ for (var i = 0; i < n; i = i + 1) {
   val = ntoggle.activate().value();
 }
 
-print ntoggle.value();
-print clock() - start;
+print(ntoggle.value());
+print(clock() - start);

--- a/test/benchmark/properties.lox
+++ b/test/benchmark/properties.lox
@@ -103,4 +103,4 @@ while (i < 500000) {
   i = i + 1;
 }
 
-print clock() - start;
+print(clock() - start);

--- a/test/benchmark/string_equality.lox
+++ b/test/benchmark/string_equality.lox
@@ -211,9 +211,9 @@ while (i < 100000) {
 }
 
 var elapsed = clock() - start;
-print "loop";
-print loopTime;
-print "elapsed";
-print elapsed;
-print "equals";
-print elapsed - loopTime;
+print("loop");
+print(loopTime);
+print("elapsed");
+print(elapsed);
+print("equals");
+print(elapsed - loopTime);

--- a/test/benchmark/trees.lox
+++ b/test/benchmark/trees.lox
@@ -24,6 +24,6 @@ class Tree {
 var tree = Tree(8);
 var start = clock();
 for (var i = 0; i < 100; i = i + 1) {
-  if (tree.walk() != 122068) print "Error";
+  if (tree.walk() != 122068) print("Error");
 }
-print clock() - start;
+print(clock() - start);

--- a/test/benchmark/zoo.lox
+++ b/test/benchmark/zoo.lox
@@ -27,5 +27,5 @@ while (sum < 10000000) {
             + zoo.mouse();
 }
 
-print sum;
-print clock() - start;
+print(sum);
+print(clock() - start);

--- a/test/benchmark/zoo_batch.lox
+++ b/test/benchmark/zoo_batch.lox
@@ -31,6 +31,6 @@ while (clock() - start < 10) {
   batch = batch + 1;
 }
 
-print sum;
-print batch;
-print clock() - start;
+print(sum);
+print(batch);
+print(clock() - start);

--- a/test/block/empty.lox
+++ b/test/block/empty.lox
@@ -4,4 +4,4 @@
 if (true) {}
 if (false) {} else {}
 
-print "ok"; // expect: ok
+print("ok"); // expect: ok

--- a/test/block/scope.lox
+++ b/test/block/scope.lox
@@ -2,7 +2,7 @@ var a = "outer";
 
 {
   var a = "inner";
-  print a; // expect: inner
+  print(a); // expect: inner
 }
 
-print a; // expect: outer
+print(a); // expect: outer

--- a/test/bool/equality.lox
+++ b/test/bool/equality.lox
@@ -1,23 +1,23 @@
-print true == true;    // expect: true
-print true == false;   // expect: false
-print false == true;   // expect: false
-print false == false;  // expect: true
+print(true == true);    // expect: true
+print(true == false);   // expect: false
+print(false == true);   // expect: false
+print(false == false);  // expect: true
 
 // Not equal to other types.
-print true == 1;        // expect: false
-print false == 0;       // expect: false
-print true == "true";   // expect: false
-print false == "false"; // expect: false
-print false == "";      // expect: false
+print(true == 1);        // expect: false
+print(false == 0);       // expect: false
+print(true == "true");   // expect: false
+print(false == "false"); // expect: false
+print(false == "");      // expect: false
 
-print true != true;    // expect: false
-print true != false;   // expect: true
-print false != true;   // expect: true
-print false != false;  // expect: false
+print(true != true);    // expect: false
+print(true != false);   // expect: true
+print(false != true);   // expect: true
+print(false != false);  // expect: false
 
 // Not equal to other types.
-print true != 1;        // expect: true
-print false != 0;       // expect: true
-print true != "true";   // expect: true
-print false != "false"; // expect: true
-print false != "";      // expect: true
+print(true != 1);        // expect: true
+print(false != 0);       // expect: true
+print(true != "true");   // expect: true
+print(false != "false"); // expect: true
+print(false != "");      // expect: true

--- a/test/bool/not.lox
+++ b/test/bool/not.lox
@@ -1,3 +1,3 @@
-print !true;    // expect: false
-print !false;   // expect: true
-print !!true;   // expect: true
+print(!true);    // expect: false
+print(!false);   // expect: true
+print(!!true);   // expect: true

--- a/test/class/empty.lox
+++ b/test/class/empty.lox
@@ -1,3 +1,3 @@
 class Foo {}
 
-print Foo; // expect: Foo
+print(Foo); // expect: Foo

--- a/test/class/inherited_method.lox
+++ b/test/class/inherited_method.lox
@@ -1,18 +1,18 @@
 class Foo {
   inFoo() {
-    print "in foo";
+    print("in foo");
   }
 }
 
 class Bar < Foo {
   inBar() {
-    print "in bar";
+    print("in bar");
   }
 }
 
 class Baz < Bar {
   inBaz() {
-    print "in baz";
+    print("in baz");
   }
 }
 

--- a/test/class/local_inherit_other.lox
+++ b/test/class/local_inherit_other.lox
@@ -5,4 +5,4 @@ fun f() {
   return B;
 }
 
-print f(); // expect: B
+print(f()); // expect: B

--- a/test/class/local_reference_self.lox
+++ b/test/class/local_reference_self.lox
@@ -5,5 +5,5 @@
     }
   }
 
-  print Foo().returnSelf(); // expect: Foo
+  print(Foo().returnSelf()); // expect: Foo
 }

--- a/test/class/reference_self.lox
+++ b/test/class/reference_self.lox
@@ -4,4 +4,4 @@ class Foo {
   }
 }
 
-print Foo().returnSelf(); // expect: Foo
+print(Foo().returnSelf()); // expect: Foo

--- a/test/closure/assign_to_closure.lox
+++ b/test/closure/assign_to_closure.lox
@@ -4,16 +4,16 @@ var g;
 {
   var local = "local";
   fun f_() {
-    print local;
+    print(local);
     local = "after f";
-    print local;
+    print(local);
   }
   f = f_;
 
   fun g_() {
-    print local;
+    print(local);
     local = "after g";
-    print local;
+    print(local);
   }
   g = g_;
 }

--- a/test/closure/assign_to_shadowed_later.lox
+++ b/test/closure/assign_to_shadowed_later.lox
@@ -7,7 +7,7 @@ var a = "global";
 
   var a = "inner";
   assign();
-  print a; // expect: inner
+  print(a); // expect: inner
 }
 
-print a; // expect: assigned
+print(a); // expect: assigned

--- a/test/closure/close_over_function_parameter.lox
+++ b/test/closure/close_over_function_parameter.lox
@@ -2,7 +2,7 @@ var f;
 
 fun foo(param) {
   fun f_() {
-    print param;
+    print(param);
   }
   f = f_;
 }

--- a/test/closure/close_over_later_variable.lox
+++ b/test/closure/close_over_later_variable.lox
@@ -7,8 +7,8 @@ fun f() {
   var a = "a";
   var b = "b";
   fun g() {
-    print b; // expect: b
-    print a; // expect: a
+    print(b); // expect: b
+    print(a); // expect: a
   }
   g();
 }

--- a/test/closure/close_over_method_parameter.lox
+++ b/test/closure/close_over_method_parameter.lox
@@ -3,7 +3,7 @@ var f;
 class Foo {
   method(param) {
     fun f_() {
-      print param;
+      print(param);
     }
     f = f_;
   }

--- a/test/closure/closed_closure_in_function.lox
+++ b/test/closure/closed_closure_in_function.lox
@@ -3,7 +3,7 @@ var f;
 {
   var local = "local";
   fun f_() {
-    print local;
+    print(local);
   }
   f = f_;
 }

--- a/test/closure/nested_closure.lox
+++ b/test/closure/nested_closure.lox
@@ -7,9 +7,9 @@ fun f1() {
     fun f3() {
       var c = "c";
       fun f4() {
-        print a;
-        print b;
-        print c;
+        print(a);
+        print(b);
+        print(c);
       }
       f = f4;
     }

--- a/test/closure/open_closure_in_function.lox
+++ b/test/closure/open_closure_in_function.lox
@@ -1,7 +1,7 @@
 {
   var local = "local";
   fun f() {
-    print local; // expect: local
+    print(local); // expect: local
   }
   f();
 }

--- a/test/closure/reference_closure_multiple_times.lox
+++ b/test/closure/reference_closure_multiple_times.lox
@@ -3,8 +3,8 @@ var f;
 {
   var a = "a";
   fun f_() {
-    print a;
-    print a;
+    print(a);
+    print(a);
   }
   f = f_;
 }

--- a/test/closure/reuse_closure_slot.lox
+++ b/test/closure/reuse_closure_slot.lox
@@ -3,7 +3,7 @@
 
   {
     var a = "a";
-    fun f_() { print a; }
+    fun f_() { print(a); }
     f = f_;
   }
 

--- a/test/closure/shadow_closure_with_local.lox
+++ b/test/closure/shadow_closure_with_local.lox
@@ -2,11 +2,11 @@
   var foo = "closure";
   fun f() {
     {
-      print foo; // expect: closure
+      print(foo); // expect: closure
       var foo = "shadow";
-      print foo; // expect: shadow
+      print(foo); // expect: shadow
     }
-    print foo; // expect: closure
+    print(foo); // expect: closure
   }
   f();
 }

--- a/test/closure/unused_closure.lox
+++ b/test/closure/unused_closure.lox
@@ -10,4 +10,4 @@
 }
 
 // If we get here, we didn't segfault when a went out of scope.
-print "ok"; // expect: ok
+print("ok"); // expect: ok

--- a/test/closure/unused_later_closure.lox
+++ b/test/closure/unused_later_closure.lox
@@ -24,5 +24,5 @@ var closure;
     }
   }
 
-  print closure(); // expect: a
+  print(closure()); // expect: a
 }

--- a/test/comments/line_at_eof.lox
+++ b/test/comments/line_at_eof.lox
@@ -1,2 +1,2 @@
-print "ok"; // expect: ok
+print("ok"); // expect: ok
 // comment

--- a/test/comments/unicode.lox
+++ b/test/comments/unicode.lox
@@ -6,4 +6,4 @@
 // Other stuff: ឃᢆ᯽₪ℜ↩⊗┺░
 // Emoji: ☃☺♣
 
-print "ok"; // expect: ok
+print("ok"); // expect: ok

--- a/test/constructor/arguments.lox
+++ b/test/constructor/arguments.lox
@@ -1,11 +1,11 @@
 class Foo {
   init(a, b) {
-    print "init"; // expect: init
+    print("init"); // expect: init
     this.a = a;
     this.b = b;
   }
 }
 
 var foo = Foo(1, 2);
-print foo.a; // expect: 1
-print foo.b; // expect: 2
+print(foo.a); // expect: 1
+print(foo.b); // expect: 2

--- a/test/constructor/call_init_early_return.lox
+++ b/test/constructor/call_init_early_return.lox
@@ -1,10 +1,10 @@
 class Foo {
   init() {
-    print "init";
+    print("init");
     return;
-    print "nope";
+    print("nope");
   }
 }
 
 var foo = Foo(); // expect: init
-print foo; // expect: Foo instance
+print(foo); // expect: Foo instance

--- a/test/constructor/call_init_explicitly.lox
+++ b/test/constructor/call_init_explicitly.lox
@@ -1,6 +1,6 @@
 class Foo {
   init(arg) {
-    print "Foo.init(" + arg + ")";
+    print("Foo.init(" + arg + ")");
     this.field = "init";
   }
 }
@@ -9,7 +9,7 @@ var foo = Foo("one"); // expect: Foo.init(one)
 foo.field = "field";
 
 var foo2 = foo.init("two"); // expect: Foo.init(two)
-print foo2; // expect: Foo instance
+print(foo2); // expect: Foo instance
 
 // Make sure init() doesn't create a fresh instance.
-print foo.field; // expect: init
+print(foo.field); // expect: init

--- a/test/constructor/default.lox
+++ b/test/constructor/default.lox
@@ -1,4 +1,4 @@
 class Foo {}
 
 var foo = Foo();
-print foo; // expect: Foo instance
+print(foo); // expect: Foo instance

--- a/test/constructor/early_return.lox
+++ b/test/constructor/early_return.lox
@@ -1,10 +1,10 @@
 class Foo {
   init() {
-    print "init";
+    print("init");
     return;
-    print "nope";
+    print("nope");
   }
 }
 
 var foo = Foo(); // expect: init
-print foo; // expect: Foo instance
+print(foo); // expect: Foo instance

--- a/test/constructor/init_not_method.lox
+++ b/test/constructor/init_not_method.lox
@@ -1,12 +1,12 @@
 class Foo {
   init(arg) {
-    print "Foo.init(" + arg + ")";
+    print("Foo.init(" + arg + ")");
     this.field = "init";
   }
 }
 
 fun init() {
-  print "not initializer";
+  print("not initializer");
 }
 
 init(); // expect: not initializer

--- a/test/constructor/return_in_nested_function.lox
+++ b/test/constructor/return_in_nested_function.lox
@@ -3,8 +3,8 @@ class Foo {
     fun init() {
       return "bar";
     }
-    print init(); // expect: bar
+    print(init()); // expect: bar
   }
 }
 
-print Foo(); // expect: Foo instance
+print(Foo()); // expect: Foo instance

--- a/test/field/call_function_field.lox
+++ b/test/field/call_function_field.lox
@@ -1,9 +1,9 @@
 class Foo {}
 
 fun bar(a, b) {
-  print "bar";
-  print a;
-  print b;
+  print("bar");
+  print(a);
+  print(b);
 }
 
 var foo = Foo();

--- a/test/field/get_and_set_method.lox
+++ b/test/field/get_and_set_method.lox
@@ -1,12 +1,12 @@
 // Bound methods have identity equality.
 class Foo {
   method(a) {
-    print "method";
-    print a;
+    print("method");
+    print(a);
   }
   other(a) {
-    print "other";
-    print a;
+    print("other");
+    print(a);
   }
 }
 

--- a/test/field/many.lox
+++ b/test/field/many.lox
@@ -86,85 +86,85 @@ fun setFields() {
 setFields();
 
 fun printFields() {
-  print foo.apple; // expect: apple
-  print foo.apricot; // expect: apricot
-  print foo.avocado; // expect: avocado
-  print foo.banana; // expect: banana
-  print foo.bilberry; // expect: bilberry
-  print foo.blackberry; // expect: blackberry
-  print foo.blackcurrant; // expect: blackcurrant
-  print foo.blueberry; // expect: blueberry
-  print foo.boysenberry; // expect: boysenberry
-  print foo.cantaloupe; // expect: cantaloupe
-  print foo.cherimoya; // expect: cherimoya
-  print foo.cherry; // expect: cherry
-  print foo.clementine; // expect: clementine
-  print foo.cloudberry; // expect: cloudberry
-  print foo.coconut; // expect: coconut
-  print foo.cranberry; // expect: cranberry
-  print foo.currant; // expect: currant
-  print foo.damson; // expect: damson
-  print foo.date; // expect: date
-  print foo.dragonfruit; // expect: dragonfruit
-  print foo.durian; // expect: durian
-  print foo.elderberry; // expect: elderberry
-  print foo.feijoa; // expect: feijoa
-  print foo.fig; // expect: fig
-  print foo.gooseberry; // expect: gooseberry
-  print foo.grape; // expect: grape
-  print foo.grapefruit; // expect: grapefruit
-  print foo.guava; // expect: guava
-  print foo.honeydew; // expect: honeydew
-  print foo.huckleberry; // expect: huckleberry
-  print foo.jabuticaba; // expect: jabuticaba
-  print foo.jackfruit; // expect: jackfruit
-  print foo.jambul; // expect: jambul
-  print foo.jujube; // expect: jujube
-  print foo.juniper; // expect: juniper
-  print foo.kiwifruit; // expect: kiwifruit
-  print foo.kumquat; // expect: kumquat
-  print foo.lemon; // expect: lemon
-  print foo.lime; // expect: lime
-  print foo.longan; // expect: longan
-  print foo.loquat; // expect: loquat
-  print foo.lychee; // expect: lychee
-  print foo.mandarine; // expect: mandarine
-  print foo.mango; // expect: mango
-  print foo.marionberry; // expect: marionberry
-  print foo.melon; // expect: melon
-  print foo.miracle; // expect: miracle
-  print foo.mulberry; // expect: mulberry
-  print foo.nance; // expect: nance
-  print foo.nectarine; // expect: nectarine
-  print foo.olive; // expect: olive
-  print foo.orange; // expect: orange
-  print foo.papaya; // expect: papaya
-  print foo.passionfruit; // expect: passionfruit
-  print foo.peach; // expect: peach
-  print foo.pear; // expect: pear
-  print foo.persimmon; // expect: persimmon
-  print foo.physalis; // expect: physalis
-  print foo.pineapple; // expect: pineapple
-  print foo.plantain; // expect: plantain
-  print foo.plum; // expect: plum
-  print foo.plumcot; // expect: plumcot
-  print foo.pomegranate; // expect: pomegranate
-  print foo.pomelo; // expect: pomelo
-  print foo.quince; // expect: quince
-  print foo.raisin; // expect: raisin
-  print foo.rambutan; // expect: rambutan
-  print foo.raspberry; // expect: raspberry
-  print foo.redcurrant; // expect: redcurrant
-  print foo.salak; // expect: salak
-  print foo.salmonberry; // expect: salmonberry
-  print foo.satsuma; // expect: satsuma
-  print foo.strawberry; // expect: strawberry
-  print foo.tamarillo; // expect: tamarillo
-  print foo.tamarind; // expect: tamarind
-  print foo.tangerine; // expect: tangerine
-  print foo.tomato; // expect: tomato
-  print foo.watermelon; // expect: watermelon
-  print foo.yuzu; // expect: yuzu
+  print(foo.apple); // expect: apple
+  print(foo.apricot); // expect: apricot
+  print(foo.avocado); // expect: avocado
+  print(foo.banana); // expect: banana
+  print(foo.bilberry); // expect: bilberry
+  print(foo.blackberry); // expect: blackberry
+  print(foo.blackcurrant); // expect: blackcurrant
+  print(foo.blueberry); // expect: blueberry
+  print(foo.boysenberry); // expect: boysenberry
+  print(foo.cantaloupe); // expect: cantaloupe
+  print(foo.cherimoya); // expect: cherimoya
+  print(foo.cherry); // expect: cherry
+  print(foo.clementine); // expect: clementine
+  print(foo.cloudberry); // expect: cloudberry
+  print(foo.coconut); // expect: coconut
+  print(foo.cranberry); // expect: cranberry
+  print(foo.currant); // expect: currant
+  print(foo.damson); // expect: damson
+  print(foo.date); // expect: date
+  print(foo.dragonfruit); // expect: dragonfruit
+  print(foo.durian); // expect: durian
+  print(foo.elderberry); // expect: elderberry
+  print(foo.feijoa); // expect: feijoa
+  print(foo.fig); // expect: fig
+  print(foo.gooseberry); // expect: gooseberry
+  print(foo.grape); // expect: grape
+  print(foo.grapefruit); // expect: grapefruit
+  print(foo.guava); // expect: guava
+  print(foo.honeydew); // expect: honeydew
+  print(foo.huckleberry); // expect: huckleberry
+  print(foo.jabuticaba); // expect: jabuticaba
+  print(foo.jackfruit); // expect: jackfruit
+  print(foo.jambul); // expect: jambul
+  print(foo.jujube); // expect: jujube
+  print(foo.juniper); // expect: juniper
+  print(foo.kiwifruit); // expect: kiwifruit
+  print(foo.kumquat); // expect: kumquat
+  print(foo.lemon); // expect: lemon
+  print(foo.lime); // expect: lime
+  print(foo.longan); // expect: longan
+  print(foo.loquat); // expect: loquat
+  print(foo.lychee); // expect: lychee
+  print(foo.mandarine); // expect: mandarine
+  print(foo.mango); // expect: mango
+  print(foo.marionberry); // expect: marionberry
+  print(foo.melon); // expect: melon
+  print(foo.miracle); // expect: miracle
+  print(foo.mulberry); // expect: mulberry
+  print(foo.nance); // expect: nance
+  print(foo.nectarine); // expect: nectarine
+  print(foo.olive); // expect: olive
+  print(foo.orange); // expect: orange
+  print(foo.papaya); // expect: papaya
+  print(foo.passionfruit); // expect: passionfruit
+  print(foo.peach); // expect: peach
+  print(foo.pear); // expect: pear
+  print(foo.persimmon); // expect: persimmon
+  print(foo.physalis); // expect: physalis
+  print(foo.pineapple); // expect: pineapple
+  print(foo.plantain); // expect: plantain
+  print(foo.plum); // expect: plum
+  print(foo.plumcot); // expect: plumcot
+  print(foo.pomegranate); // expect: pomegranate
+  print(foo.pomelo); // expect: pomelo
+  print(foo.quince); // expect: quince
+  print(foo.raisin); // expect: raisin
+  print(foo.rambutan); // expect: rambutan
+  print(foo.raspberry); // expect: raspberry
+  print(foo.redcurrant); // expect: redcurrant
+  print(foo.salak); // expect: salak
+  print(foo.salmonberry); // expect: salmonberry
+  print(foo.satsuma); // expect: satsuma
+  print(foo.strawberry); // expect: strawberry
+  print(foo.tamarillo); // expect: tamarillo
+  print(foo.tamarind); // expect: tamarind
+  print(foo.tangerine); // expect: tangerine
+  print(foo.tomato); // expect: tomato
+  print(foo.watermelon); // expect: watermelon
+  print(foo.yuzu); // expect: yuzu
 }
 
 printFields();

--- a/test/field/method.lox
+++ b/test/field/method.lox
@@ -1,9 +1,9 @@
 class Foo {
   bar(arg) {
-    print arg;
+    print(arg);
   }
 }
 
 var bar = Foo().bar;
-print "got method"; // expect: got method
+print("got method"); // expect: got method
 bar("arg");          // expect: arg

--- a/test/field/method_binds_this.lox
+++ b/test/field/method_binds_this.lox
@@ -1,7 +1,7 @@
 class Foo {
   sayName(a) {
-    print this.name;
-    print a;
+    print(this.name);
+    print(a);
   }
 }
 

--- a/test/field/on_instance.lox
+++ b/test/field/on_instance.lox
@@ -2,8 +2,8 @@ class Foo {}
 
 var foo = Foo();
 
-print foo.bar = "bar value"; // expect: bar value
-print foo.baz = "baz value"; // expect: baz value
+print(foo.bar = "bar value"); // expect: bar value
+print(foo.baz = "baz value"); // expect: baz value
 
-print foo.bar; // expect: bar value
-print foo.baz; // expect: baz value
+print(foo.bar); // expect: bar value
+print(foo.baz); // expect: baz value

--- a/test/for/closure_in_body.lox
+++ b/test/for/closure_in_body.lox
@@ -5,8 +5,8 @@ var f3;
 for (var i = 1; i < 4; i = i + 1) {
   var j = i;
   fun f() {
-    print i;
-    print j;
+    print(i);
+    print(j);
   }
 
   if (j == 1) f1 = f;

--- a/test/for/return_closure.lox
+++ b/test/for/return_closure.lox
@@ -1,7 +1,7 @@
 fun f() {
   for (;;) {
     var i = "i";
-    fun g() { print i; }
+    fun g() { print(i); }
     return g;
   }
 }

--- a/test/for/return_inside.lox
+++ b/test/for/return_inside.lox
@@ -5,5 +5,5 @@ fun f() {
   }
 }
 
-print f();
+print(f());
 // expect: i

--- a/test/for/scope.lox
+++ b/test/for/scope.lox
@@ -3,11 +3,11 @@
 
   // New variable is in inner scope.
   for (var i = 0; i < 1; i = i + 1) {
-    print i; // expect: 0
+    print(i); // expect: 0
 
     // Loop body is in second inner scope.
     var i = -1;
-    print i; // expect: -1
+    print(i); // expect: -1
   }
 }
 
@@ -17,10 +17,10 @@
 
   // Goes out of scope after loop.
   var i = "after";
-  print i; // expect: after
+  print(i); // expect: after
 
   // Can reuse an existing variable.
   for (i = 0; i < 1; i = i + 1) {
-    print i; // expect: 0
+    print(i); // expect: 0
   }
 }

--- a/test/for/syntax.lox
+++ b/test/for/syntax.lox
@@ -1,12 +1,12 @@
 // Single-expression body.
-for (var c = 0; c < 3;) print c = c + 1;
+for (var c = 0; c < 3;) print(c = c + 1);
 // expect: 1
 // expect: 2
 // expect: 3
 
 // Block body.
 for (var a = 0; a < 3; a = a + 1) {
-  print a;
+  print(a);
 }
 // expect: 0
 // expect: 1
@@ -16,18 +16,18 @@ for (var a = 0; a < 3; a = a + 1) {
 fun foo() {
   for (;;) return "done";
 }
-print foo(); // expect: done
+print(foo()); // expect: done
 
 // No variable.
 var i = 0;
-for (; i < 2; i = i + 1) print i;
+for (; i < 2; i = i + 1) print(i);
 // expect: 0
 // expect: 1
 
 // No condition.
 fun bar() {
   for (var i = 0;; i = i + 1) {
-    print i;
+    print(i);
     if (i >= 2) return;
   }
 }
@@ -38,7 +38,7 @@ bar();
 
 // No increment.
 for (var i = 0; i < 2;) {
-  print i;
+  print(i);
   i = i + 1;
 }
 // expect: 0

--- a/test/function/empty_body.lox
+++ b/test/function/empty_body.lox
@@ -1,2 +1,2 @@
 fun f() {}
-print f(); // expect: nil
+print(f()); // expect: nil

--- a/test/function/extra_arguments.lox
+++ b/test/function/extra_arguments.lox
@@ -1,6 +1,6 @@
 fun f(a, b) {
-  print a;
-  print b;
+  print(a);
+  print(b);
 }
 
 f(1, 2, 3, 4); // expect runtime error: Expected 2 arguments but got 4.

--- a/test/function/local_recursion.lox
+++ b/test/function/local_recursion.lox
@@ -4,5 +4,5 @@
     return fib(n - 1) + fib(n - 2);
   }
 
-  print fib(8); // expect: 21
+  print(fib(8)); // expect: 21
 }

--- a/test/function/mutual_recursion.lox
+++ b/test/function/mutual_recursion.lox
@@ -8,5 +8,5 @@ fun isOdd(n) {
   return isEven(n - 1);
 }
 
-print isEven(4); // expect: true
-print isOdd(3); // expect: true
+print(isEven(4)); // expect: true
+print(isOdd(3)); // expect: true

--- a/test/function/nested_call_with_arguments.lox
+++ b/test/function/nested_call_with_arguments.lox
@@ -7,7 +7,7 @@ fun returnFunCallWithArg(func, arg) {
 }
 
 fun printArg(arg) {
-  print arg;
+  print(arg);
 }
 
 returnFunCallWithArg(printArg, "hello world"); // expect: hello world

--- a/test/function/parameters.lox
+++ b/test/function/parameters.lox
@@ -1,26 +1,26 @@
 fun f0() { return 0; }
-print f0(); // expect: 0
+print(f0()); // expect: 0
 
 fun f1(a) { return a; }
-print f1(1); // expect: 1
+print(f1(1)); // expect: 1
 
 fun f2(a, b) { return a + b; }
-print f2(1, 2); // expect: 3
+print(f2(1, 2)); // expect: 3
 
 fun f3(a, b, c) { return a + b + c; }
-print f3(1, 2, 3); // expect: 6
+print(f3(1, 2, 3)); // expect: 6
 
 fun f4(a, b, c, d) { return a + b + c + d; }
-print f4(1, 2, 3, 4); // expect: 10
+print(f4(1, 2, 3, 4)); // expect: 10
 
 fun f5(a, b, c, d, e) { return a + b + c + d + e; }
-print f5(1, 2, 3, 4, 5); // expect: 15
+print(f5(1, 2, 3, 4, 5)); // expect: 15
 
 fun f6(a, b, c, d, e, f) { return a + b + c + d + e + f; }
-print f6(1, 2, 3, 4, 5, 6); // expect: 21
+print(f6(1, 2, 3, 4, 5, 6)); // expect: 21
 
 fun f7(a, b, c, d, e, f, g) { return a + b + c + d + e + f + g; }
-print f7(1, 2, 3, 4, 5, 6, 7); // expect: 28
+print(f7(1, 2, 3, 4, 5, 6, 7)); // expect: 28
 
 fun f8(a, b, c, d, e, f, g, h) { return a + b + c + d + e + f + g + h; }
-print f8(1, 2, 3, 4, 5, 6, 7, 8); // expect: 36
+print(f8(1, 2, 3, 4, 5, 6, 7, 8)); // expect: 36

--- a/test/function/print.lox
+++ b/test/function/print.lox
@@ -1,4 +1,4 @@
 fun foo() {}
-print foo; // expect: <fn foo>
+print(foo); // expect: <fn foo>
 
-print clock; // expect: <native fn>
+print(clock); // expect: <native fn>

--- a/test/function/recursion.lox
+++ b/test/function/recursion.lox
@@ -3,4 +3,4 @@ fun fib(n) {
   return fib(n - 1) + fib(n - 2);
 }
 
-print fib(8); // expect: 21
+print(fib(8)); // expect: 21

--- a/test/if/dangling_else.lox
+++ b/test/if/dangling_else.lox
@@ -1,3 +1,3 @@
 // A dangling else binds to the right-most if.
-if (true) if (false) print("bad"; else print "good"); // expect: good
-if (false) if (true) print("bad"; else print "bad");
+if (true) if (false) print("bad"); else print("good"); // expect: good
+if (false) if (true) print("bad"); else print("bad");

--- a/test/if/dangling_else.lox
+++ b/test/if/dangling_else.lox
@@ -1,3 +1,3 @@
 // A dangling else binds to the right-most if.
-if (true) if (false) print "bad"; else print "good"; // expect: good
-if (false) if (true) print "bad"; else print "bad";
+if (true) if (false) print("bad"; else print "good"); // expect: good
+if (false) if (true) print("bad"; else print "bad");

--- a/test/if/else.lox
+++ b/test/if/else.lox
@@ -1,6 +1,6 @@
 // Evaluate the 'else' expression if the condition is false.
-if (true) print "good"; else print "bad"; // expect: good
-if (false) print "bad"; else print "good"; // expect: good
+if (true) print("good"; else print "bad"); // expect: good
+if (false) print("bad"; else print "good"); // expect: good
 
 // Allow block body.
-if (false) nil; else { print "block"; } // expect: block
+if (false) nil; else { print("block"); } // expect: block

--- a/test/if/else.lox
+++ b/test/if/else.lox
@@ -1,6 +1,6 @@
 // Evaluate the 'else' expression if the condition is false.
-if (true) print("good"; else print "bad"); // expect: good
-if (false) print("bad"; else print "good"); // expect: good
+if (true) print("good"); else prin("bad"); // expect: good
+if (false) print("bad"); else print("good"); // expect: good
 
 // Allow block body.
 if (false) nil; else { print("block"); } // expect: block

--- a/test/if/if.lox
+++ b/test/if/if.lox
@@ -1,10 +1,10 @@
 // Evaluate the 'then' expression if the condition is true.
-if (true) print "good"; // expect: good
-if (false) print "bad";
+if (true) print("good"); // expect: good
+if (false) print("bad");
 
 // Allow block body.
-if (true) { print "block"; } // expect: block
+if (true) { print("block"); } // expect: block
 
 // Assignment in if condition.
 var a = false;
-if (a = true) print a; // expect: true
+if (a = true) print(a); // expect: true

--- a/test/if/truth.lox
+++ b/test/if/truth.lox
@@ -1,8 +1,8 @@
 // False and nil are false.
-if (false) print "bad"; else print "false"; // expect: false
-if (nil) print "bad"; else print "nil"; // expect: nil
+if (false) print("bad"; else print "false"); // expect: false
+if (nil) print("bad"; else print "nil"); // expect: nil
 
 // Everything else is true.
-if (true) print true; // expect: true
-if (0) print 0; // expect: 0
-if ("") print "empty"; // expect: empty
+if (true) print(true); // expect: true
+if (0) print(0); // expect: 0
+if ("") print("empty"); // expect: empty

--- a/test/if/truth.lox
+++ b/test/if/truth.lox
@@ -1,6 +1,6 @@
 // False and nil are false.
-if (false) print("bad"; else print "false"); // expect: false
-if (nil) print("bad"; else print "nil"); // expect: nil
+if (false) print("bad"); else print("false"); // expect: false
+if (nil) print("bad"); else print("nil"); // expect: nil
 
 // Everything else is true.
 if (true) print(true); // expect: true

--- a/test/inheritance/constructor.lox
+++ b/test/inheritance/constructor.lox
@@ -4,7 +4,7 @@ class A {
   }
 
   test() {
-    print this.field;
+    print(this.field);
   }
 }
 

--- a/test/inheritance/inherit_methods.lox
+++ b/test/inheritance/inherit_methods.lox
@@ -1,11 +1,11 @@
 class Foo {
-  methodOnFoo() { print "foo"; }
-  override() { print "foo"; }
+  methodOnFoo() { print("foo"); }
+  override() { print("foo"); }
 }
 
 class Bar < Foo {
-  methodOnBar() { print "bar"; }
-  override() { print "bar"; }
+  methodOnBar() { print("bar"); }
+  override() { print("bar"); }
 }
 
 var bar = Bar();

--- a/test/inheritance/set_fields_from_base_class.lox
+++ b/test/inheritance/set_fields_from_base_class.lox
@@ -5,8 +5,8 @@ class Foo {
   }
 
   fooPrint() {
-    print this.field1;
-    print this.field2;
+    print(this.field1);
+    print(this.field2);
   }
 }
 
@@ -17,8 +17,8 @@ class Bar < Foo {
   }
 
   barPrint() {
-    print this.field1;
-    print this.field2;
+    print(this.field1);
+    print(this.field2);
   }
 }
 

--- a/test/logical_operator/and.lox
+++ b/test/logical_operator/and.lox
@@ -1,13 +1,13 @@
 // Note: These tests implicitly depend on ints being truthy.
 
 // Return the first non-true argument.
-print false and 1; // expect: false
-print true and 1; // expect: 1
-print 1 and 2 and false; // expect: false
+print(false and 1); // expect: false
+print(true and 1); // expect: 1
+print(1 and 2 and false); // expect: false
 
 // Return the last argument if all are true.
-print 1 and true; // expect: true
-print 1 and 2 and 3; // expect: 3
+print(1 and true); // expect: true
+print(1 and 2 and 3); // expect: 3
 
 // Short-circuit at the first false argument.
 var a = "before";
@@ -15,5 +15,5 @@ var b = "before";
 (a = true) and
     (b = false) and
     (a = "bad");
-print a; // expect: true
-print b; // expect: false
+print(a); // expect: true
+print(b); // expect: false

--- a/test/logical_operator/and_truth.lox
+++ b/test/logical_operator/and_truth.lox
@@ -1,8 +1,8 @@
 // False and nil are false.
-print false and "bad"; // expect: false
-print nil and "bad"; // expect: nil
+print(false and "bad"); // expect: false
+print(nil and "bad"); // expect: nil
 
 // Everything else is true.
-print true and "ok"; // expect: ok
-print 0 and "ok"; // expect: ok
-print "" and "ok"; // expect: ok
+print(true and "ok"); // expect: ok
+print(0 and "ok"); // expect: ok
+print("" and "ok"); // expect: ok

--- a/test/logical_operator/or.lox
+++ b/test/logical_operator/or.lox
@@ -1,13 +1,13 @@
 // Note: These tests implicitly depend on ints being truthy.
 
 // Return the first true argument.
-print 1 or true; // expect: 1
-print false or 1; // expect: 1
-print false or false or true; // expect: true
+print(1 or true); // expect: 1
+print(false or 1); // expect: 1
+print(false or false or true); // expect: true
 
 // Return the last argument if all are false.
-print false or false; // expect: false
-print false or false or false; // expect: false
+print(false or false); // expect: false
+print(false or false or false); // expect: false
 
 // Short-circuit at the first true argument.
 var a = "before";
@@ -15,5 +15,5 @@ var b = "before";
 (a = false) or
     (b = true) or
     (a = "bad");
-print a; // expect: false
-print b; // expect: true
+print(a); // expect: false
+print(b); // expect: true

--- a/test/logical_operator/or_truth.lox
+++ b/test/logical_operator/or_truth.lox
@@ -1,8 +1,8 @@
 // False and nil are false.
-print false or "ok"; // expect: ok
-print nil or "ok"; // expect: ok
+print(false or "ok"); // expect: ok
+print(nil or "ok"); // expect: ok
 
 // Everything else is true.
-print true or "ok"; // expect: true
-print 0 or "ok"; // expect: 0
-print "s" or "ok"; // expect: s
+print(true or "ok"); // expect: true
+print(0 or "ok"); // expect: 0
+print("s" or "ok"); // expect: s

--- a/test/method/arity.lox
+++ b/test/method/arity.lox
@@ -11,12 +11,12 @@ class Foo {
 }
 
 var foo = Foo();
-print foo.method0(); // expect: no args
-print foo.method1(1); // expect: 1
-print foo.method2(1, 2); // expect: 3
-print foo.method3(1, 2, 3); // expect: 6
-print foo.method4(1, 2, 3, 4); // expect: 10
-print foo.method5(1, 2, 3, 4, 5); // expect: 15
-print foo.method6(1, 2, 3, 4, 5, 6); // expect: 21
-print foo.method7(1, 2, 3, 4, 5, 6, 7); // expect: 28
-print foo.method8(1, 2, 3, 4, 5, 6, 7, 8); // expect: 36
+print(foo.method0()); // expect: no args
+print(foo.method1(1)); // expect: 1
+print(foo.method2(1, 2)); // expect: 3
+print(foo.method3(1, 2, 3)); // expect: 6
+print(foo.method4(1, 2, 3, 4)); // expect: 10
+print(foo.method5(1, 2, 3, 4, 5)); // expect: 15
+print(foo.method6(1, 2, 3, 4, 5, 6)); // expect: 21
+print(foo.method7(1, 2, 3, 4, 5, 6, 7)); // expect: 28
+print(foo.method8(1, 2, 3, 4, 5, 6, 7, 8)); // expect: 36

--- a/test/method/empty_block.lox
+++ b/test/method/empty_block.lox
@@ -2,4 +2,4 @@ class Foo {
   bar() {}
 }
 
-print Foo().bar(); // expect: nil
+print(Foo().bar()); // expect: nil

--- a/test/method/extra_arguments.lox
+++ b/test/method/extra_arguments.lox
@@ -1,7 +1,7 @@
 class Foo {
   method(a, b) {
-    print a;
-    print b;
+    print(a);
+    print(b);
   }
 }
 

--- a/test/method/print_bound_method.lox
+++ b/test/method/print_bound_method.lox
@@ -2,4 +2,4 @@ class Foo {
   method() { }
 }
 var foo = Foo();
-print foo.method; // expect: <fn method>
+print(foo.method); // expect: <fn method>

--- a/test/method/refer_to_name.lox
+++ b/test/method/refer_to_name.lox
@@ -1,6 +1,6 @@
 class Foo {
   method() {
-    print method; // expect runtime error: Undefined variable 'method'.
+    print(method); // expect runtime error: Undefined variable 'method'.
   }
 }
 

--- a/test/nil/literal.lox
+++ b/test/nil/literal.lox
@@ -1,1 +1,1 @@
-print nil; // expect: nil
+print(nil); // expect: nil

--- a/test/number/literals.lox
+++ b/test/number/literals.lox
@@ -1,7 +1,7 @@
-print 123;     // expect: 123
-print 987654;  // expect: 987654
-print 0;       // expect: 0
-print -0;      // expect: -0
+print(123);     // expect: 123
+print(987654);  // expect: 987654
+print(0);       // expect: 0
+print(-0);      // expect: -0
 
-print 123.456; // expect: 123.456
-print -0.001;  // expect: -0.001
+print(123.456); // expect: 123.456
+print(-0.001);  // expect: -0.001

--- a/test/number/nan_equality.lox
+++ b/test/number/nan_equality.lox
@@ -1,8 +1,8 @@
 var nan = 0/0;
 
-print nan == 0; // expect: false
-print nan != 1; // expect: true
+print(nan == 0); // expect: false
+print(nan != 1); // expect: true
 
 // NaN is not equal to self.
-print nan == nan; // expect: false
-print nan != nan; // expect: true
+print(nan == nan); // expect: false
+print(nan != nan); // expect: true

--- a/test/operator/add.lox
+++ b/test/operator/add.lox
@@ -1,2 +1,2 @@
-print 123 + 456; // expect: 579
-print "str" + "ing"; // expect: string
+print(123 + 456); // expect: 579
+print("str" + "ing"); // expect: string

--- a/test/operator/comparison.lox
+++ b/test/operator/comparison.lox
@@ -1,25 +1,25 @@
-print 1 < 2;    // expect: true
-print 2 < 2;    // expect: false
-print 2 < 1;    // expect: false
+print(1 < 2);    // expect: true
+print(2 < 2);    // expect: false
+print(2 < 1);    // expect: false
 
-print 1 <= 2;    // expect: true
-print 2 <= 2;    // expect: true
-print 2 <= 1;    // expect: false
+print(1 <= 2);    // expect: true
+print(2 <= 2);    // expect: true
+print(2 <= 1);    // expect: false
 
-print 1 > 2;    // expect: false
-print 2 > 2;    // expect: false
-print 2 > 1;    // expect: true
+print(1 > 2);    // expect: false
+print(2 > 2);    // expect: false
+print(2 > 1);    // expect: true
 
-print 1 >= 2;    // expect: false
-print 2 >= 2;    // expect: true
-print 2 >= 1;    // expect: true
+print(1 >= 2);    // expect: false
+print(2 >= 2);    // expect: true
+print(2 >= 1);    // expect: true
 
 // Zero and negative zero compare the same.
-print 0 < -0; // expect: false
-print -0 < 0; // expect: false
-print 0 > -0; // expect: false
-print -0 > 0; // expect: false
-print 0 <= -0; // expect: true
-print -0 <= 0; // expect: true
-print 0 >= -0; // expect: true
-print -0 >= 0; // expect: true
+print(0 < -0); // expect: false
+print(-0 < 0); // expect: false
+print(0 > -0); // expect: false
+print(-0 > 0); // expect: false
+print(0 <= -0); // expect: true
+print(-0 <= 0); // expect: true
+print(0 >= -0); // expect: true
+print(-0 >= 0); // expect: true

--- a/test/operator/divide.lox
+++ b/test/operator/divide.lox
@@ -1,2 +1,2 @@
-print 8 / 2;         // expect: 4
-print 12.34 / 12.34;  // expect: 1
+print(8 / 2);         // expect: 4
+print(12.34 / 12.34);  // expect: 1

--- a/test/operator/equals.lox
+++ b/test/operator/equals.lox
@@ -1,14 +1,14 @@
-print nil == nil; // expect: true
+print(nil == nil); // expect: true
 
-print true == true; // expect: true
-print true == false; // expect: false
+print(true == true); // expect: true
+print(true == false); // expect: false
 
-print 1 == 1; // expect: true
-print 1 == 2; // expect: false
+print(1 == 1); // expect: true
+print(1 == 2); // expect: false
 
-print "str" == "str"; // expect: true
-print "str" == "ing"; // expect: false
+print("str" == "str"); // expect: true
+print("str" == "ing"); // expect: false
 
-print nil == false; // expect: false
-print false == 0; // expect: false
-print 0 == "0"; // expect: false
+print(nil == false); // expect: false
+print(false == 0); // expect: false
+print(0 == "0"); // expect: false

--- a/test/operator/equals_class.lox
+++ b/test/operator/equals_class.lox
@@ -2,12 +2,12 @@
 class Foo {}
 class Bar {}
 
-print Foo == Foo; // expect: true
-print Foo == Bar; // expect: false
-print Bar == Foo; // expect: false
-print Bar == Bar; // expect: true
+print(Foo == Foo); // expect: true
+print(Foo == Bar); // expect: false
+print(Bar == Foo); // expect: false
+print(Bar == Bar); // expect: true
 
-print Foo == "Foo"; // expect: false
-print Foo == nil;   // expect: false
-print Foo == 123;   // expect: false
-print Foo == true;  // expect: false
+print(Foo == "Foo"); // expect: false
+print(Foo == nil);   // expect: false
+print(Foo == 123);   // expect: false
+print(Foo == true);  // expect: false

--- a/test/operator/equals_method.lox
+++ b/test/operator/equals_method.lox
@@ -7,7 +7,7 @@ var foo = Foo();
 var fooMethod = foo.method;
 
 // Same bound method.
-print fooMethod == fooMethod; // expect: true
+print(fooMethod == fooMethod); // expect: true
 
 // Different closurizations.
-print foo.method == foo.method; // expect: false
+print(foo.method == foo.method); // expect: false

--- a/test/operator/multiply.lox
+++ b/test/operator/multiply.lox
@@ -1,2 +1,2 @@
-print 5 * 3; // expect: 15
-print 12.34 * 0.3; // expect: 3.702
+print(5 * 3); // expect: 15
+print(12.34 * 0.3); // expect: 3.702

--- a/test/operator/negate.lox
+++ b/test/operator/negate.lox
@@ -1,3 +1,3 @@
-print -(3); // expect: -3
-print --(3); // expect: 3
-print ---(3); // expect: -3
+print(-(3)); // expect: -3
+print(--(3)); // expect: 3
+print(---(3)); // expect: -3

--- a/test/operator/not.lox
+++ b/test/operator/not.lox
@@ -1,13 +1,13 @@
-print !true;     // expect: false
-print !false;    // expect: true
-print !!true;    // expect: true
+print(!true);     // expect: false
+print(!false);    // expect: true
+print(!!true);    // expect: true
 
-print !123;      // expect: false
-print !0;        // expect: false
+print(!123);      // expect: false
+print(!0);        // expect: false
 
-print !nil;     // expect: true
+print(!nil);     // expect: true
 
-print !"";       // expect: false
+print(!"");       // expect: false
 
 fun foo() {}
-print !foo;      // expect: false
+print(!foo);      // expect: false

--- a/test/operator/not_class.lox
+++ b/test/operator/not_class.lox
@@ -1,3 +1,3 @@
 class Bar {}
-print !Bar;      // expect: false
-print !Bar();    // expect: false
+print(!Bar);      // expect: false
+print(!Bar());    // expect: false

--- a/test/operator/not_equals.lox
+++ b/test/operator/not_equals.lox
@@ -1,14 +1,14 @@
-print nil != nil; // expect: false
+print(nil != nil); // expect: false
 
-print true != true; // expect: false
-print true != false; // expect: true
+print(true != true); // expect: false
+print(true != false); // expect: true
 
-print 1 != 1; // expect: false
-print 1 != 2; // expect: true
+print(1 != 1); // expect: false
+print(1 != 2); // expect: true
 
-print "str" != "str"; // expect: false
-print "str" != "ing"; // expect: true
+print("str" != "str"); // expect: false
+print("str" != "ing"); // expect: true
 
-print nil != false; // expect: true
-print false != 0; // expect: true
-print 0 != "0"; // expect: true
+print(nil != false); // expect: true
+print(false != 0); // expect: true
+print(0 != "0"); // expect: true

--- a/test/operator/subtract.lox
+++ b/test/operator/subtract.lox
@@ -1,2 +1,2 @@
-print 4 - 3; // expect: 1
-print 1.2 - 1.2; // expect: 0
+print(4 - 3); // expect: 1
+print(1.2 - 1.2); // expect: 0

--- a/test/precedence.lox
+++ b/test/precedence.lox
@@ -1,32 +1,32 @@
 // * has higher precedence than +.
-print 2 + 3 * 4; // expect: 14
+print(2 + 3 * 4); // expect: 14
 
 // * has higher precedence than -.
-print 20 - 3 * 4; // expect: 8
+print(20 - 3 * 4); // expect: 8
 
 // / has higher precedence than +.
-print 2 + 6 / 3; // expect: 4
+print(2 + 6 / 3); // expect: 4
 
 // / has higher precedence than -.
-print 2 - 6 / 3; // expect: 0
+print(2 - 6 / 3); // expect: 0
 
 // < has higher precedence than ==.
-print false == 2 < 1; // expect: true
+print(false == 2 < 1); // expect: true
 
 // > has higher precedence than ==.
-print false == 1 > 2; // expect: true
+print(false == 1 > 2); // expect: true
 
 // <= has higher precedence than ==.
-print false == 2 <= 1; // expect: true
+print(false == 2 <= 1); // expect: true
 
 // >= has higher precedence than ==.
-print false == 1 >= 2; // expect: true
+print(false == 1 >= 2); // expect: true
 
 // 1 - 1 is not space-sensitive.
-print 1 - 1; // expect: 0
-print 1 -1;  // expect: 0
-print 1- 1;  // expect: 0
-print 1-1;   // expect: 0
+print(1 - 1); // expect: 0
+print(1 -1);  // expect: 0
+print(1- 1);  // expect: 0
+print(1-1);   // expect: 0
 
 // Using () for grouping.
-print (2 * (6 - (2 + 2))); // expect: 4
+print((2 * (6 - (2 + 2)))); // expect: 4

--- a/test/regression/394.lox
+++ b/test/regression/394.lox
@@ -1,5 +1,5 @@
 {
   class A {}
   class B < A {}
-  print B; // expect: B
+  print(B); // expect: B
 }

--- a/test/regression/40.lox
+++ b/test/regression/40.lox
@@ -1,7 +1,7 @@
 fun caller(g) {
   g();
   // g should be a function, not nil.
-  print g == nil; // expect: false
+  print(g == nil); // expect: false
 }
 
 fun callCaller() {

--- a/test/return/after_else.lox
+++ b/test/return/after_else.lox
@@ -2,4 +2,4 @@ fun f() {
   if (false) "no"; else return "ok";
 }
 
-print f(); // expect: ok
+print(f()); // expect: ok

--- a/test/return/after_if.lox
+++ b/test/return/after_if.lox
@@ -2,4 +2,4 @@ fun f() {
   if (true) return "ok";
 }
 
-print f(); // expect: ok
+print(f()); // expect: ok

--- a/test/return/after_while.lox
+++ b/test/return/after_while.lox
@@ -2,4 +2,4 @@ fun f() {
   while (true) return "ok";
 }
 
-print f(); // expect: ok
+print(f()); // expect: ok

--- a/test/return/in_function.lox
+++ b/test/return/in_function.lox
@@ -1,6 +1,6 @@
 fun f() {
   return "ok";
-  print "bad";
+  print("bad");
 }
 
-print f(); // expect: ok
+print(f()); // expect: ok

--- a/test/return/in_method.lox
+++ b/test/return/in_method.lox
@@ -1,8 +1,8 @@
 class Foo {
   method() {
     return "ok";
-    print "bad";
+    print("bad");
   }
 }
 
-print Foo().method(); // expect: ok
+print(Foo().method()); // expect: ok

--- a/test/return/return_nil_if_no_value.lox
+++ b/test/return/return_nil_if_no_value.lox
@@ -1,6 +1,6 @@
 fun f() {
   return;
-  print "bad";
+  print("bad");
 }
 
-print f(); // expect: nil
+print(f()); // expect: nil

--- a/test/string/literals.lox
+++ b/test/string/literals.lox
@@ -1,5 +1,5 @@
-print "(" + "" + ")";   // expect: ()
-print "a string"; // expect: a string
+print("(" + "" + ")");   // expect: ()
+print("a string"); // expect: a string
 
 // Non-ASCII.
-print "A~¶Þॐஃ"; // expect: A~¶Þॐஃ
+print("A~¶Þॐஃ"); // expect: A~¶Þॐஃ

--- a/test/string/multiline.lox
+++ b/test/string/multiline.lox
@@ -1,7 +1,7 @@
 var a = "1
 2
 3";
-print a;
+print(a);
 // expect: 1
 // expect: 2
 // expect: 3

--- a/test/super/bound_method.lox
+++ b/test/super/bound_method.lox
@@ -1,6 +1,6 @@
 class A {
   method(arg) {
-    print "A.method(" + arg + ")";
+    print("A.method(" + arg + ")");
   }
 }
 
@@ -10,7 +10,7 @@ class B < A {
   }
 
   method(arg) {
-    print "B.method(" + arg + ")";
+    print("B.method(" + arg + ")");
   }
 }
 

--- a/test/super/call_other_method.lox
+++ b/test/super/call_other_method.lox
@@ -1,12 +1,12 @@
 class Base {
   foo() {
-    print "Base.foo()";
+    print("Base.foo()");
   }
 }
 
 class Derived < Base {
   bar() {
-    print "Derived.bar()";
+    print("Derived.bar()");
     super.foo();
   }
 }

--- a/test/super/call_same_method.lox
+++ b/test/super/call_same_method.lox
@@ -1,12 +1,12 @@
 class Base {
   foo() {
-    print "Base.foo()";
+    print("Base.foo()");
   }
 }
 
 class Derived < Base {
   foo() {
-    print "Derived.foo()";
+    print("Derived.foo()");
     super.foo();
   }
 }

--- a/test/super/closure.lox
+++ b/test/super/closure.lox
@@ -14,4 +14,4 @@ class Derived < Base {
 }
 
 var closure = Derived().getClosure();
-print closure(); // expect: Base
+print(closure()); // expect: Base

--- a/test/super/constructor.lox
+++ b/test/super/constructor.lox
@@ -1,12 +1,12 @@
 class Base {
   init(a, b) {
-    print "Base.init(" + a + ", " + b + ")";
+    print("Base.init(" + a + ", " + b + ")");
   }
 }
 
 class Derived < Base {
   init() {
-    print "Derived.init()";
+    print("Derived.init()");
     super.init("a", "b");
   }
 }

--- a/test/super/extra_arguments.lox
+++ b/test/super/extra_arguments.lox
@@ -1,12 +1,12 @@
 class Base {
   foo(a, b) {
-    print "Base.foo(" + a + ", " + b + ")";
+    print("Base.foo(" + a + ", " + b + ")");
   }
 }
 
 class Derived < Base {
   foo() {
-    print "Derived.foo()"; // expect: Derived.foo()
+    print("Derived.foo()"); // expect: Derived.foo()
     super.foo("a", "b", "c", "d"); // expect runtime error: Expected 2 arguments but got 4.
   }
 }

--- a/test/super/indirectly_inherited.lox
+++ b/test/super/indirectly_inherited.lox
@@ -1,6 +1,6 @@
 class A {
   foo() {
-    print "A.foo()";
+    print("A.foo()");
   }
 }
 
@@ -8,7 +8,7 @@ class B < A {}
 
 class C < B {
   foo() {
-    print "C.foo()";
+    print("C.foo()");
     super.foo();
   }
 }

--- a/test/super/missing_arguments.lox
+++ b/test/super/missing_arguments.lox
@@ -1,6 +1,6 @@
 class Base {
   foo(a, b) {
-    print "Base.foo(" + a + ", " + b + ")";
+    print("Base.foo(" + a + ", " + b + ")");
   }
 }
 

--- a/test/super/reassign_superclass.lox
+++ b/test/super/reassign_superclass.lox
@@ -1,6 +1,6 @@
 class Base {
   method() {
-    print "Base.method()";
+    print("Base.method()");
   }
 }
 
@@ -12,7 +12,7 @@ class Derived < Base {
 
 class OtherBase {
   method() {
-    print "OtherBase.method()";
+    print("OtherBase.method()");
   }
 }
 

--- a/test/super/super_in_closure_in_inherited_method.lox
+++ b/test/super/super_in_closure_in_inherited_method.lox
@@ -1,6 +1,6 @@
 class A {
   say() {
-    print "A";
+    print("A");
   }
 }
 
@@ -13,13 +13,13 @@ class B < A {
   }
 
   say() {
-    print "B";
+    print("B");
   }
 }
 
 class C < B {
   say() {
-    print "C";
+    print("C");
   }
 }
 

--- a/test/super/super_in_inherited_method.lox
+++ b/test/super/super_in_inherited_method.lox
@@ -1,6 +1,6 @@
 class A {
   say() {
-    print "A";
+    print("A");
   }
 }
 
@@ -10,13 +10,13 @@ class B < A {
   }
 
   say() {
-    print "B";
+    print("B");
   }
 }
 
 class C < B {
   say() {
-    print "C";
+    print("C");
   }
 }
 

--- a/test/super/this_in_superclass_method.lox
+++ b/test/super/this_in_superclass_method.lox
@@ -12,5 +12,5 @@ class Derived < Base {
 }
 
 var derived = Derived("a", "b");
-print derived.a; // expect: a
-print derived.b; // expect: b
+print(derived.a); // expect: a
+print(derived.b); // expect: b

--- a/test/this/closure.lox
+++ b/test/this/closure.lox
@@ -10,4 +10,4 @@ class Foo {
 }
 
 var closure = Foo().getClosure();
-print closure(); // expect: Foo
+print(closure()); // expect: Foo

--- a/test/this/nested_class.lox
+++ b/test/this/nested_class.lox
@@ -1,13 +1,13 @@
 class Outer {
   method() {
-    print this; // expect: Outer instance
+    print(this); // expect: Outer instance
 
     fun f() {
-      print this; // expect: Outer instance
+      print(this); // expect: Outer instance
 
       class Inner {
         method() {
-          print this; // expect: Inner instance
+          print(this); // expect: Inner instance
         }
       }
 

--- a/test/this/nested_closure.lox
+++ b/test/this/nested_closure.lox
@@ -16,4 +16,4 @@ class Foo {
 }
 
 var closure = Foo().getClosure();
-print closure()()(); // expect: Foo
+print(closure()()()); // expect: Foo

--- a/test/this/this_in_method.lox
+++ b/test/this/this_in_method.lox
@@ -3,4 +3,4 @@ class Foo {
   baz() { return "baz"; }
 }
 
-print Foo().bar().baz(); // expect: baz
+print(Foo().bar().baz()); // expect: baz

--- a/test/variable/early_bound.lox
+++ b/test/variable/early_bound.lox
@@ -1,7 +1,7 @@
 var a = "outer";
 {
   fun foo() {
-    print a;
+    print(a);
   }
 
   foo(); // expect: outer

--- a/test/variable/in_middle_of_block.lox
+++ b/test/variable/in_middle_of_block.lox
@@ -1,10 +1,10 @@
 {
   var a = "a";
-  print a; // expect: a
+  print(a); // expect: a
   var b = a + " b";
-  print b; // expect: a b
+  print(b); // expect: a b
   var c = a + " c";
-  print c; // expect: a c
+  print(c); // expect: a c
   var d = b + " d";
-  print d; // expect: a b d
+  print(d); // expect: a b d
 }

--- a/test/variable/in_nested_block.lox
+++ b/test/variable/in_nested_block.lox
@@ -1,6 +1,6 @@
 {
   var a = "outer";
   {
-    print a; // expect: outer
+    print(a); // expect: outer
   }
 }

--- a/test/variable/local_from_method.lox
+++ b/test/variable/local_from_method.lox
@@ -2,7 +2,7 @@ var foo = "variable";
 
 class Foo {
   method() {
-    print foo;
+    print(foo);
   }
 }
 

--- a/test/variable/redeclare_global.lox
+++ b/test/variable/redeclare_global.lox
@@ -1,3 +1,3 @@
 var a = "1";
 var a;
-print a; // expect: nil
+print(a); // expect: nil

--- a/test/variable/redefine_global.lox
+++ b/test/variable/redefine_global.lox
@@ -1,3 +1,3 @@
 var a = "1";
 var a = "2";
-print a; // expect: 2
+print(a); // expect: 2

--- a/test/variable/scope_reuse_in_different_blocks.lox
+++ b/test/variable/scope_reuse_in_different_blocks.lox
@@ -1,9 +1,9 @@
 {
   var a = "first";
-  print a; // expect: first
+  print(a); // expect: first
 }
 
 {
   var a = "second";
-  print a; // expect: second
+  print(a); // expect: second
 }

--- a/test/variable/shadow_and_local.lox
+++ b/test/variable/shadow_and_local.lox
@@ -1,8 +1,8 @@
 {
   var a = "outer";
   {
-    print a; // expect: outer
+    print(a); // expect: outer
     var a = "inner";
-    print a; // expect: inner
+    print(a); // expect: inner
   }
 }

--- a/test/variable/shadow_global.lox
+++ b/test/variable/shadow_global.lox
@@ -1,6 +1,6 @@
 var a = "global";
 {
   var a = "shadow";
-  print a; // expect: shadow
+  print(a); // expect: shadow
 }
-print a; // expect: global
+print(a); // expect: global

--- a/test/variable/shadow_local.lox
+++ b/test/variable/shadow_local.lox
@@ -2,7 +2,7 @@
   var a = "local";
   {
     var a = "shadow";
-    print a; // expect: shadow
+    print(a); // expect: shadow
   }
-  print a; // expect: local
+  print(a); // expect: local
 }

--- a/test/variable/undefined_global.lox
+++ b/test/variable/undefined_global.lox
@@ -1,1 +1,1 @@
-print notDefined;  // expect runtime error: Undefined variable 'notDefined'.
+print(notDefined);  // expect runtime error: Undefined variable 'notDefined'.

--- a/test/variable/undefined_local.lox
+++ b/test/variable/undefined_local.lox
@@ -1,3 +1,3 @@
 {
-  print notDefined;  // expect runtime error: Undefined variable 'notDefined'.
+  print(notDefined);  // expect runtime error: Undefined variable 'notDefined'.
 }

--- a/test/variable/uninitialized.lox
+++ b/test/variable/uninitialized.lox
@@ -1,2 +1,2 @@
 var a;
-print a; // expect: nil
+print(a); // expect: nil

--- a/test/variable/unreached_undefined.lox
+++ b/test/variable/unreached_undefined.lox
@@ -1,5 +1,5 @@
 if (false) {
-  print notDefined;
+  print(notDefined);
 }
 
-print "ok"; // expect: ok
+print("ok"); // expect: ok

--- a/test/variable/use_global_in_initializer.lox
+++ b/test/variable/use_global_in_initializer.lox
@@ -1,3 +1,3 @@
 var a = "value";
 var a = a;
-print a; // expect: value
+print(a); // expect: value

--- a/test/while/closure_in_body.lox
+++ b/test/while/closure_in_body.lox
@@ -5,7 +5,7 @@ var f3;
 var i = 1;
 while (i < 4) {
   var j = i;
-  fun f() { print j; }
+  fun f() { print(j); }
 
   if (j == 1) f1 = f;
   else if (j == 2) f2 = f;

--- a/test/while/return_closure.lox
+++ b/test/while/return_closure.lox
@@ -1,7 +1,7 @@
 fun f() {
   while (true) {
     var i = "i";
-    fun g() { print i; }
+    fun g() { print(i); }
     return g;
   }
 }

--- a/test/while/return_inside.lox
+++ b/test/while/return_inside.lox
@@ -5,5 +5,5 @@ fun f() {
   }
 }
 
-print f();
+print(f());
 // expect: i

--- a/test/while/syntax.lox
+++ b/test/while/syntax.lox
@@ -1,6 +1,6 @@
 // Single-expression body.
 var c = 0;
-while (c < 3) print c = c + 1;
+while (c < 3) print(c = c + 1);
 // expect: 1
 // expect: 2
 // expect: 3
@@ -8,7 +8,7 @@ while (c < 3) print c = c + 1;
 // Block body.
 var a = 0;
 while (a < 3) {
-  print a;
+  print(a);
   a = a + 1;
 }
 // expect: 0

--- a/tool/gen-ast.py
+++ b/tool/gen-ast.py
@@ -298,7 +298,6 @@ if __name__ == '__main__':
         "If     : Expr cond, Stmt thenBranch, Stmt? elseBranch",
         "While  : Expr cond, Stmt body",
         "Return : Token keyword, Expr? value",
-        "Print  : Expr expr",
         "Var    : Token name, Expr? initializer",
         "Fun    : Token name, List<Token> params, List<Stmt> body",
         "Class  : Token name, VariableExpr? superclass, List<FunStmt> methods",

--- a/tool/run-test.py
+++ b/tool/run-test.py
@@ -331,8 +331,13 @@ def _defineTestSuites():
         noJavaLimits
     )
 
+    cloxxTests = _merge_dicts(
+        jloxTests,
+        { "test/print": "skip" },
+    )
+
     # cloxx behaves like jlox
-    _allSuites["cloxx"] = Suite("cloxx", jloxTests)
+    _allSuites["cloxx"] = Suite("cloxx", cloxxTests)
 
     # more suites can go here...
 


### PR DESCRIPTION
Remove `print` from language grammar and add it back as a global native function.