### PR TITLE
Make LoxClass final (but not forced)

### DIFF
--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -7,9 +7,6 @@
 
 namespace cloxx {
 
-Environment::Environment(PrivateCreationTag tag) : Traceable{tag}
-{}
-
 Environment::Environment(PrivateCreationTag tag, std::shared_ptr<Environment> const& enclosing)
     : Traceable{tag}, _enclosing{enclosing}
 {}

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -13,7 +13,6 @@ struct Token;
 
 class Environment : public Traceable {
 public:
-    Environment(PrivateCreationTag);
     Environment(PrivateCreationTag, std::shared_ptr<Environment> const& enclosing);
 
     void define(std::string const& name, std::shared_ptr<LoxObject> const& value);

--- a/src/GC.cpp
+++ b/src/GC.cpp
@@ -35,7 +35,7 @@ Traceable::Traceable(PrivateCreationTag)
 
 GarbageCollector::GarbageCollector()
 {
-    _root = create<Environment>();
+    _root = create<Environment>(/*closure*/ nullptr);
 }
 
 GarbageCollector::~GarbageCollector()

--- a/src/GC.cpp
+++ b/src/GC.cpp
@@ -49,6 +49,11 @@ std::shared_ptr<Environment> const& GarbageCollector::root()
     return _root;
 }
 
+void GarbageCollector::trace(std::shared_ptr<Traceable> const& traceable)
+{
+    _weakTraceables.push_back(traceable);
+}
+
 size_t GarbageCollector::collect()
 {
     size_t collectedCount = 0;

--- a/src/GC.cpp
+++ b/src/GC.cpp
@@ -49,11 +49,6 @@ std::shared_ptr<Environment> const& GarbageCollector::root()
     return _root;
 }
 
-void GarbageCollector::trace(std::shared_ptr<Traceable> const& traceable)
-{
-    _weakTraceables.push_back(traceable);
-}
-
 size_t GarbageCollector::collect()
 {
     size_t collectedCount = 0;

--- a/src/GC.hpp
+++ b/src/GC.hpp
@@ -46,13 +46,12 @@ public:
     std::shared_ptr<T> create(Args&&... args)
     {
         auto traceable = std::make_shared<T>(Traceable::PrivateCreationTag{}, std::forward<Args>(args)...);
-        trace(traceable);
+        _weakTraceables.push_back(traceable);
         return traceable;
     }
 
     std::shared_ptr<Environment> const& root();
 
-    void trace(std::shared_ptr<Traceable> const& traceable);
     size_t collect();
 
 private:

--- a/src/GC.hpp
+++ b/src/GC.hpp
@@ -46,12 +46,13 @@ public:
     std::shared_ptr<T> create(Args&&... args)
     {
         auto traceable = std::make_shared<T>(Traceable::PrivateCreationTag{}, std::forward<Args>(args)...);
-        _weakTraceables.push_back(traceable);
+        trace(traceable);
         return traceable;
     }
 
     std::shared_ptr<Environment> const& root();
 
+    void trace(std::shared_ptr<Traceable> const& traceable);
     size_t collect();
 
 private:

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -93,7 +93,7 @@ void Interpreter::interpret(Stmt const& stmt)
 
 void Interpreter::visit(BlockStmt const& stmt)
 {
-    auto blockEnv = _runtime.create<Environment>(_environment);
+    auto blockEnv = _runtime.createEnvironment(_environment);
     executeBlock(stmt.stmts, blockEnv);
 }
 
@@ -104,7 +104,7 @@ void Interpreter::visit(ExprStmt const& stmt)
 
 void Interpreter::visit(ForStmt const& stmt)
 {
-    ScopeSwitcher _{this, _runtime.create<Environment>(_environment)};
+    ScopeSwitcher _{this, _runtime.createEnvironment(_environment)};
 
     if (stmt.initializer) {
         stmt.initializer->accept(*this);
@@ -197,7 +197,7 @@ void Interpreter::visit(ClassStmt const& stmt)
 
     auto enclosingEnvironment = _environment;
     if (superclass) {
-        _environment = _runtime.create<Environment>(_environment);
+        _environment = _runtime.createEnvironment(_environment);
         _environment->define("super", superclass);
     }
 
@@ -208,7 +208,7 @@ void Interpreter::visit(ClassStmt const& stmt)
         methods.emplace(method.name.lexeme, function);
     }
 
-    auto klass = _runtime.create<LoxClass>(&_runtime, stmt.name.lexeme, superclass, methods);
+    auto klass = _runtime.create<LoxClass>(stmt.name.lexeme, superclass, methods);
 
     if (superclass) {
         _environment = enclosingEnvironment;
@@ -534,7 +534,7 @@ std::shared_ptr<LoxFunction> Interpreter::makeFunction(bool isInitializer, Token
         return _runtime.getNil();
     };
 
-    return _runtime.create<LoxUserFunction>(&_runtime, _environment, isInitializer, name, params, body, executor);
+    return _runtime.create<LoxUserFunction>(_environment, isInitializer, name, params, body, executor);
 }
 
 } // namespace cloxx

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -208,7 +208,7 @@ void Interpreter::visit(ClassStmt const& stmt)
         methods.emplace(method.name.lexeme, function);
     }
 
-    auto klass = _runtime.create<LoxClass>(stmt.name.lexeme, superclass, methods);
+    auto klass = _runtime.create<LoxClass>(stmt.name.lexeme, superclass, methods, /*objectFactory*/ nullptr);
 
     if (superclass) {
         _environment = enclosingEnvironment;

--- a/src/Lox.cpp
+++ b/src/Lox.cpp
@@ -25,16 +25,15 @@ auto makeBuiltIns(Runtime* runtime)
     std::map<std::string, std::shared_ptr<LoxObject>> builtIns;
 
     // global functions
-    builtIns.emplace("print", runtime->create<LoxNativeFunction>(runtime, 1, [runtime](auto& /*instance*/, auto& args) {
+    builtIns.emplace("print", runtime->create<LoxNativeFunction>(1, [runtime](auto& /*instance*/, auto& args) {
         std::cout << args[0]->toString() << '\n';
         return runtime->getNil();
     }));
-    builtIns.emplace("clock",
-                     runtime->create<LoxNativeFunction>(runtime, 0, [runtime](auto& /*instance*/, auto& /*args*/) {
-                         auto duration = std::chrono::steady_clock::now().time_since_epoch();
-                         auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-                         return runtime->toLoxNumber(millis / 1000.0);
-                     }));
+    builtIns.emplace("clock", runtime->create<LoxNativeFunction>(0, [runtime](auto& /*instance*/, auto& /*args*/) {
+        auto duration = std::chrono::steady_clock::now().time_since_epoch();
+        auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        return runtime->toLoxNumber(millis / 1000.0);
+    }));
 
     return builtIns;
 }

--- a/src/LoxBool.cpp
+++ b/src/LoxBool.cpp
@@ -48,7 +48,7 @@ bool LoxBool::equals(std::shared_ptr<LoxObject> const& object)
 
 std::shared_ptr<LoxClass> createBoolClass(Runtime* runtime)
 {
-    return runtime->create<LoxBoolClass>(runtime, "Bool", runtime->objectClass(), createBoolMethods(runtime));
+    return runtime->create<LoxBoolClass>("Bool", runtime->objectClass(), createBoolMethods(runtime));
 }
 
 } // namespace cloxx

--- a/src/LoxBool.cpp
+++ b/src/LoxBool.cpp
@@ -11,16 +11,6 @@ namespace cloxx {
 
 namespace {
 
-class LoxBoolClass : public LoxClass {
-public:
-    using LoxClass::LoxClass;
-
-    std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass) override
-    {
-        return _runtime->create<LoxBool>(klass);
-    }
-};
-
 std::map<std::string, std::shared_ptr<LoxFunction>> createBoolMethods(Runtime* /*runtime*/)
 {
     std::map<std::string, std::shared_ptr<LoxFunction>> methods;
@@ -48,7 +38,10 @@ bool LoxBool::equals(std::shared_ptr<LoxObject> const& object)
 
 std::shared_ptr<LoxClass> createBoolClass(Runtime* runtime)
 {
-    return runtime->create<LoxBoolClass>("Bool", runtime->objectClass(), createBoolMethods(runtime));
+    return runtime->create<LoxClass>("Bool", runtime->objectClass(), createBoolMethods(runtime),
+                                     [runtime](auto const& klass) {
+                                         return runtime->create<LoxBool>(klass);
+                                     });
 }
 
 } // namespace cloxx

--- a/src/LoxClass.cpp
+++ b/src/LoxClass.cpp
@@ -9,8 +9,9 @@ namespace cloxx {
 
 LoxClass::LoxClass(PrivateCreationTag tag, Runtime* runtime, std::string name,
                    std::shared_ptr<LoxClass> const& superclass,
-                   std::map<std::string, std::shared_ptr<LoxFunction>> methods)
-    : LoxObject{tag}, _runtime{runtime}, _name{std::move(name)}, _superclass{superclass}, _methods{std::move(methods)}
+                   std::map<std::string, std::shared_ptr<LoxFunction>> methods, LoxObjectFactory objectFactory)
+    : LoxObject{tag}, _runtime{runtime}, _name{std::move(name)}, _superclass{superclass}, _methods{std::move(methods)},
+      _objectFactory{objectFactory}
 {}
 
 std::shared_ptr<LoxFunction> LoxClass::findMethod(std::string const& name) const
@@ -74,6 +75,10 @@ void LoxClass::reclaim()
 
 std::shared_ptr<LoxObject> LoxClass::createInstance(std::shared_ptr<LoxClass> const& klass)
 {
+    if (_objectFactory) {
+        return _objectFactory(klass);
+    }
+
     if (_superclass) {
         return _superclass->createInstance(klass);
     }

--- a/src/LoxClass.cpp
+++ b/src/LoxClass.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<LoxObject> LoxClass::createInstance(std::shared_ptr<LoxClass> co
         return _superclass->createInstance(klass);
     }
 
-    return _runtime->create<LoxObject>(klass);
+    return _runtime->create<LoxObject>(klass)
 }
 
 } // namespace cloxx

--- a/src/LoxClass.cpp
+++ b/src/LoxClass.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<LoxObject> LoxClass::createInstance(std::shared_ptr<LoxClass> co
         return _superclass->createInstance(klass);
     }
 
-    return _runtime->create<LoxObject>(klass)
+    return _runtime->create<LoxObject>(klass);
 }
 
 } // namespace cloxx

--- a/src/LoxClass.hpp
+++ b/src/LoxClass.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 

--- a/src/LoxClass.hpp
+++ b/src/LoxClass.hpp
@@ -10,10 +10,12 @@ namespace cloxx {
 class LoxFunction;
 class Runtime;
 
+using LoxObjectFactory = std::function<std::shared_ptr<LoxObject>(std::shared_ptr<LoxClass> const&)>;
+
 class LoxClass : public LoxObject, public Callable {
 public:
     LoxClass(PrivateCreationTag tag, Runtime* runtime, std::string name, std::shared_ptr<LoxClass> const& superclass,
-             std::map<std::string, std::shared_ptr<LoxFunction>> methods);
+             std::map<std::string, std::shared_ptr<LoxFunction>> methods, LoxObjectFactory objectFactory);
 
     std::shared_ptr<LoxFunction> findMethod(std::string const& name) const;
 
@@ -26,15 +28,14 @@ public:
     void enumerateTraceables(Traceable::Enumerator const& enumerator) override;
     void reclaim() override;
 
-    virtual std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass);
-
-protected:
-    Runtime* const _runtime;
-
 private:
+    std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass);
+
+    Runtime* const _runtime;
     std::string _name;
     std::shared_ptr<LoxClass> _superclass;
     std::map<std::string, std::shared_ptr<LoxFunction>> _methods;
+    LoxObjectFactory _objectFactory;
 };
 
 } // namespace cloxx

--- a/src/LoxFunction.cpp
+++ b/src/LoxFunction.cpp
@@ -5,13 +5,13 @@
 
 namespace cloxx {
 
-LoxFunction::LoxFunction(PrivateCreationTag tag, std::shared_ptr<LoxClass> const& klass) : LoxObject{tag, klass}
+LoxFunction::LoxFunction(PrivateCreationTag tag, Runtime* runtime) : LoxObject{tag, runtime, runtime->functionClass()}
 {}
 
 std::shared_ptr<LoxClass> createFunctionClass(Runtime* runtime)
 {
     std::map<std::string, std::shared_ptr<LoxFunction>> funcClassMethods;
-    return runtime->create<LoxClass>(runtime, "Function", runtime->objectClass(), funcClassMethods);
+    return runtime->create<LoxClass>("Function", runtime->objectClass(), funcClassMethods);
 }
 
 } // namespace cloxx

--- a/src/LoxFunction.cpp
+++ b/src/LoxFunction.cpp
@@ -11,7 +11,7 @@ LoxFunction::LoxFunction(PrivateCreationTag tag, Runtime* runtime) : LoxObject{t
 std::shared_ptr<LoxClass> createFunctionClass(Runtime* runtime)
 {
     std::map<std::string, std::shared_ptr<LoxFunction>> funcClassMethods;
-    return runtime->create<LoxClass>("Function", runtime->objectClass(), funcClassMethods);
+    return runtime->create<LoxClass>("Function", runtime->objectClass(), funcClassMethods, /*objectFactory*/ nullptr);
 }
 
 } // namespace cloxx

--- a/src/LoxFunction.cpp
+++ b/src/LoxFunction.cpp
@@ -1,7 +1,7 @@
 #include "LoxFunction.hpp"
 
-#include "Interpreter.hpp"
 #include "LoxClass.hpp"
+#include "Runtime.hpp"
 
 namespace cloxx {
 

--- a/src/LoxFunction.hpp
+++ b/src/LoxFunction.hpp
@@ -12,7 +12,7 @@ class LoxClass;
 
 class LoxFunction : public LoxObject, public Callable {
 public:
-    LoxFunction(PrivateCreationTag tag, std::shared_ptr<LoxClass> const& klass);
+    LoxFunction(PrivateCreationTag tag, Runtime* runtime);
 
     virtual std::shared_ptr<LoxFunction> bind(std::shared_ptr<LoxObject> const& instance) const = 0;
 };

--- a/src/LoxList.cpp
+++ b/src/LoxList.cpp
@@ -38,16 +38,6 @@ public:
     bool isStringifying = false;
 };
 
-class LoxListClass : public LoxClass {
-public:
-    using LoxClass::LoxClass;
-
-    std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass) override
-    {
-        return _runtime->create<LoxList>(klass);
-    }
-};
-
 auto toListInstance(std::shared_ptr<LoxObject> const& instance)
 {
     LOX_ASSERT(std::dynamic_pointer_cast<LoxList>(instance));
@@ -134,7 +124,10 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createListMethods(Runtime* r
 
 std::shared_ptr<LoxClass> createListClass(Runtime* runtime)
 {
-    return runtime->create<LoxListClass>("List", runtime->objectClass(), createListMethods(runtime));
+    return runtime->create<LoxClass>("List", runtime->objectClass(), createListMethods(runtime),
+                                     [runtime](auto const& klass) {
+                                         return runtime->create<LoxList>(klass);
+                                     });
 }
 
 } // namespace cloxx

--- a/src/LoxList.cpp
+++ b/src/LoxList.cpp
@@ -58,7 +58,7 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createListMethods(Runtime* r
 {
     std::map<std::string, std::shared_ptr<LoxFunction>> methods;
 
-    methods.emplace("append", runtime->create<LoxNativeFunction>(runtime, /*arity*/ 1, [](auto& instance, auto& args) {
+    methods.emplace("append", runtime->create<LoxNativeFunction>(/*arity*/ 1, [](auto& instance, auto& args) {
         LOX_ASSERT(args.size() == 1);
 
         auto& items = toListInstance(instance)->items;
@@ -66,46 +66,44 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createListMethods(Runtime* r
         return args[0];
     }));
 
-    methods.emplace("get",
-                    runtime->create<LoxNativeFunction>(runtime, /*arity*/ 1, [runtime](auto& instance, auto& args) {
-                        LOX_ASSERT(args.size() == 1);
+    methods.emplace("get", runtime->create<LoxNativeFunction>(/*arity*/ 1, [runtime](auto& instance, auto& args) {
+        LOX_ASSERT(args.size() == 1);
 
-                        std::shared_ptr<LoxObject> result;
-                        if (auto number = dynamic_cast<LoxNumber*>(args[0].get())) {
-                            auto& items = toListInstance(instance)->items;
-                            if (auto index = static_cast<size_t>(number->value); index < items.size()) {
-                                result = items[index];
-                            }
-                        }
-                        if (!result) {
-                            result = runtime->getNil(); // FIXME: throw exception
-                        }
-                        return result;
-                    }));
+        std::shared_ptr<LoxObject> result;
+        if (auto number = dynamic_cast<LoxNumber*>(args[0].get())) {
+            auto& items = toListInstance(instance)->items;
+            if (auto index = static_cast<size_t>(number->value); index < items.size()) {
+                result = items[index];
+            }
+        }
+        if (!result) {
+            result = runtime->getNil(); // FIXME: throw exception
+        }
+        return result;
+    }));
 
-    methods.emplace("set",
-                    runtime->create<LoxNativeFunction>(runtime, /*arity*/ 2, [runtime](auto& instance, auto& args) {
-                        LOX_ASSERT(args.size() == 2);
+    methods.emplace("set", runtime->create<LoxNativeFunction>(/*arity*/ 2, [runtime](auto& instance, auto& args) {
+        LOX_ASSERT(args.size() == 2);
 
-                        std::shared_ptr<LoxObject> result;
-                        if (auto number = dynamic_cast<LoxNumber*>(args[0].get())) {
-                            auto& items = toListInstance(instance)->items;
-                            if (auto index = static_cast<size_t>(number->value); index < items.size()) {
-                                items[index] = args[1];
-                                return runtime->toLoxBool(true);
-                            }
-                        }
-                        return runtime->toLoxBool(false);
-                    }));
+        std::shared_ptr<LoxObject> result;
+        if (auto number = dynamic_cast<LoxNumber*>(args[0].get())) {
+            auto& items = toListInstance(instance)->items;
+            if (auto index = static_cast<size_t>(number->value); index < items.size()) {
+                items[index] = args[1];
+                return runtime->toLoxBool(true);
+            }
+        }
+        return runtime->toLoxBool(false);
+    }));
 
     methods.emplace("length",
-                    runtime->create<LoxNativeFunction>(runtime, /*arity*/ 0, [runtime](auto& instance, auto& /*args*/) {
+                    runtime->create<LoxNativeFunction>(/*arity*/ 0, [runtime](auto& instance, auto& /*args*/) {
                         auto& items = toListInstance(instance)->items;
                         return runtime->toLoxNumber(items.size());
                     }));
 
     methods.emplace("toString",
-                    runtime->create<LoxNativeFunction>(runtime, /*arity*/ 0, [runtime](auto& instance, auto& /*args*/) {
+                    runtime->create<LoxNativeFunction>(/*arity*/ 0, [runtime](auto& instance, auto& /*args*/) {
                         auto listInstance = toListInstance(instance);
 
                         if (listInstance->isStringifying) {
@@ -136,7 +134,7 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createListMethods(Runtime* r
 
 std::shared_ptr<LoxClass> createListClass(Runtime* runtime)
 {
-    return runtime->create<LoxListClass>(runtime, "List", runtime->objectClass(), createListMethods(runtime));
+    return runtime->create<LoxListClass>("List", runtime->objectClass(), createListMethods(runtime));
 }
 
 } // namespace cloxx

--- a/src/LoxNativeFunction.cpp
+++ b/src/LoxNativeFunction.cpp
@@ -6,8 +6,7 @@ namespace cloxx {
 
 LoxNativeFunction::LoxNativeFunction(PrivateCreationTag tag, Runtime* runtime, size_t arity, Body body,
                                      std::shared_ptr<LoxObject> const& instance)
-    : LoxFunction{tag, runtime->functionClass()}, _runtime{runtime}, _arity{arity}, _body{std::move(body)},
-      _instance{instance}
+    : LoxFunction{tag, runtime}, _runtime{runtime}, _arity{arity}, _body{std::move(body)}, _instance{instance}
 {}
 
 std::string LoxNativeFunction::toString()
@@ -43,7 +42,7 @@ void LoxNativeFunction::reclaim()
 
 std::shared_ptr<LoxFunction> LoxNativeFunction::bind(std::shared_ptr<LoxObject> const& instance) const
 {
-    return _runtime->create<LoxNativeFunction>(_runtime, _arity, _body, instance);
+    return _runtime->create<LoxNativeFunction>(_arity, _body, instance);
 }
 
 } // namespace cloxx

--- a/src/LoxNil.cpp
+++ b/src/LoxNil.cpp
@@ -53,7 +53,7 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createNilMethods(Runtime* /*
 
 std::shared_ptr<LoxClass> createNilClass(Runtime* runtime)
 {
-    return runtime->create<LoxNilClass>(runtime, "Nil", runtime->objectClass(), createNilMethods(runtime));
+    return runtime->create<LoxNilClass>("Nil", runtime->objectClass(), createNilMethods(runtime));
 }
 
 } // namespace cloxx

--- a/src/LoxNil.cpp
+++ b/src/LoxNil.cpp
@@ -32,16 +32,6 @@ public:
     }
 };
 
-class LoxNilClass : public LoxClass {
-public:
-    using LoxClass::LoxClass;
-
-    std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass) override
-    {
-        return _runtime->create<LoxNil>(klass);
-    }
-};
-
 std::map<std::string, std::shared_ptr<LoxFunction>> createNilMethods(Runtime* /*runtime*/)
 {
     std::map<std::string, std::shared_ptr<LoxFunction>> methods;
@@ -53,7 +43,10 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createNilMethods(Runtime* /*
 
 std::shared_ptr<LoxClass> createNilClass(Runtime* runtime)
 {
-    return runtime->create<LoxNilClass>("Nil", runtime->objectClass(), createNilMethods(runtime));
+    return runtime->create<LoxClass>("Nil", runtime->objectClass(), createNilMethods(runtime),
+                                     [runtime](auto const& klass) {
+                                         return runtime->create<LoxNil>(klass);
+                                     });
 }
 
 } // namespace cloxx

--- a/src/LoxNumber.cpp
+++ b/src/LoxNumber.cpp
@@ -63,7 +63,7 @@ public:
 
 std::shared_ptr<LoxClass> createNumberClass(Runtime* runtime)
 {
-    return runtime->create<LoxNumberClass>(runtime, "Number", runtime->objectClass());
+    return runtime->create<LoxNumberClass>("Number", runtime->objectClass());
 }
 
 } // namespace cloxx

--- a/src/LoxNumber.cpp
+++ b/src/LoxNumber.cpp
@@ -1,7 +1,7 @@
 #include "LoxNumber.hpp"
 
-#include "Interpreter.hpp"
 #include "LoxClass.hpp"
+#include "Runtime.hpp"
 
 namespace cloxx {
 

--- a/src/LoxNumber.cpp
+++ b/src/LoxNumber.cpp
@@ -46,24 +46,14 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createNumberMethods(Runtime*
     return methods;
 }
 
-class LoxNumberClass : public LoxClass {
-public:
-    LoxNumberClass(PrivateCreationTag tag, Runtime* runtime, std::string name,
-                   std::shared_ptr<LoxClass> const& superclass)
-        : LoxClass{tag, runtime, std::move(name), superclass, createNumberMethods(runtime)}
-    {}
-
-    std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass) override
-    {
-        return _runtime->create<LoxNumber>(klass);
-    }
-};
-
 } // namespace
 
 std::shared_ptr<LoxClass> createNumberClass(Runtime* runtime)
 {
-    return runtime->create<LoxNumberClass>("Number", runtime->objectClass());
+    return runtime->create<LoxClass>("Number", runtime->objectClass(), createNumberMethods(runtime),
+                                     [runtime](auto const& klass) {
+                                         return runtime->create<LoxNumber>(klass);
+                                     });
 }
 
 } // namespace cloxx

--- a/src/LoxObject.cpp
+++ b/src/LoxObject.cpp
@@ -9,6 +9,7 @@
 #include "LoxFunction.hpp"
 
 namespace cloxx {
+
 LoxObject::LoxObject(PrivateCreationTag tag, std::shared_ptr<LoxClass> const& klass) : Traceable{tag}, _class{klass}
 {
     LOX_ASSERT(_class);

--- a/src/LoxObject.cpp
+++ b/src/LoxObject.cpp
@@ -10,7 +10,8 @@
 
 namespace cloxx {
 
-LoxObject::LoxObject(PrivateCreationTag tag, std::shared_ptr<LoxClass> const& klass) : Traceable{tag}, _class{klass}
+LoxObject::LoxObject(PrivateCreationTag tag, Runtime* /*runtime*/, std::shared_ptr<LoxClass> const& klass)
+    : Traceable{tag}, _class{klass}
 {
     LOX_ASSERT(_class);
 }
@@ -99,7 +100,7 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createObjectMethods(Runtime*
 
 std::shared_ptr<LoxClass> createObjectClass(Runtime* runtime)
 {
-    return runtime->create<LoxClass>(runtime, "Object", /*superclass*/ nullptr, createObjectMethods(runtime));
+    return runtime->create<LoxClass>("Object", /*superclass*/ nullptr, createObjectMethods(runtime));
 }
 
 } // namespace cloxx

--- a/src/LoxObject.cpp
+++ b/src/LoxObject.cpp
@@ -100,7 +100,8 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createObjectMethods(Runtime*
 
 std::shared_ptr<LoxClass> createObjectClass(Runtime* runtime)
 {
-    return runtime->create<LoxClass>("Object", /*superclass*/ nullptr, createObjectMethods(runtime));
+    return runtime->create<LoxClass>("Object", /*superclass*/ nullptr, createObjectMethods(runtime),
+                                     /*objectFactory*/ nullptr);
 }
 
 } // namespace cloxx

--- a/src/LoxObject.cpp
+++ b/src/LoxObject.cpp
@@ -45,14 +45,14 @@ void LoxObject::set(Token const& name, std::shared_ptr<LoxObject> const& value)
 
 std::string LoxObject::toString()
 {
-    if (auto method = _class->findMethod("toString"); method && method->arity() == 0) {
-        return method->bind(shared_from_this())->call({})->toString();
-    }
-
     if (!_class) {
+        // I'm an instance of Class class.
         return "Class";
     }
 
+    if (auto method = _class->findMethod("toString"); method && method->arity() == 0) {
+        return method->bind(shared_from_this())->call({})->toString();
+    }
     return _class->toString() + " instance";
 }
 

--- a/src/LoxObject.hpp
+++ b/src/LoxObject.hpp
@@ -23,7 +23,7 @@ private:
     LoxObject(PrivateCreationTag tag);
 
 public:
-    LoxObject(PrivateCreationTag tag, std::shared_ptr<LoxClass> const& klass);
+    LoxObject(PrivateCreationTag tag, Runtime* runtime, std::shared_ptr<LoxClass> const& klass);
     virtual ~LoxObject() = default;
 
     std::shared_ptr<LoxObject> get(Token const& name);

--- a/src/LoxString.cpp
+++ b/src/LoxString.cpp
@@ -46,7 +46,7 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createStringMethods(Runtime*
 
 std::shared_ptr<LoxClass> createStringClass(Runtime* runtime)
 {
-    return runtime->create<LoxStringClass>(runtime, "String", runtime->objectClass(), createStringMethods(runtime));
+    return runtime->create<LoxStringClass>("String", runtime->objectClass(), createStringMethods(runtime));
 }
 
 } // namespace cloxx

--- a/src/LoxString.cpp
+++ b/src/LoxString.cpp
@@ -25,16 +25,6 @@ bool LoxString::equals(std::shared_ptr<LoxObject> const& object)
 
 namespace {
 
-class LoxStringClass : public LoxClass {
-public:
-    using LoxClass::LoxClass;
-
-    std::shared_ptr<LoxObject> createInstance(std::shared_ptr<LoxClass> const& klass) override
-    {
-        return _runtime->create<LoxString>(klass);
-    }
-};
-
 std::map<std::string, std::shared_ptr<LoxFunction>> createStringMethods(Runtime* /*runtime*/)
 {
     std::map<std::string, std::shared_ptr<LoxFunction>> methods;
@@ -46,7 +36,10 @@ std::map<std::string, std::shared_ptr<LoxFunction>> createStringMethods(Runtime*
 
 std::shared_ptr<LoxClass> createStringClass(Runtime* runtime)
 {
-    return runtime->create<LoxStringClass>("String", runtime->objectClass(), createStringMethods(runtime));
+    return runtime->create<LoxClass>("String", runtime->objectClass(), createStringMethods(runtime),
+                                     [runtime](auto const& klass) {
+                                         return runtime->create<LoxString>(klass);
+                                     });
 }
 
 } // namespace cloxx

--- a/src/LoxUserFunction.cpp
+++ b/src/LoxUserFunction.cpp
@@ -13,7 +13,7 @@ namespace cloxx {
 LoxUserFunction::LoxUserFunction(PrivateCreationTag tag, Runtime* runtime, std::shared_ptr<Environment> const& closure,
                                  bool isInitializer, Token const& name, std::vector<Token> const& params,
                                  std::vector<Stmt> const& body, Executor const& executor)
-    : LoxFunction{tag, runtime->functionClass()}, _runtime{runtime}, _closure{closure},
+    : LoxFunction{tag, runtime}, _runtime{runtime}, _closure{closure},
       _isInitializer{isInitializer}, _name{name}, _params{params}, _body{body}, _executor{executor}
 {
     LOX_ASSERT(_closure);
@@ -23,9 +23,9 @@ std::shared_ptr<LoxFunction> LoxUserFunction::bind(std::shared_ptr<LoxObject> co
 {
     LOX_ASSERT(instance);
 
-    auto closure = _runtime->create<Environment>(_closure);
+    auto closure = _runtime->createEnvironment(_closure);
     closure->define("this", instance);
-    return _runtime->create<LoxUserFunction>(_runtime, closure, _isInitializer, _name, _params, _body, _executor);
+    return _runtime->create<LoxUserFunction>(closure, _isInitializer, _name, _params, _body, _executor);
 }
 
 std::string LoxUserFunction::toString()
@@ -42,7 +42,7 @@ std::shared_ptr<LoxObject> LoxUserFunction::call(std::vector<std::shared_ptr<Lox
 {
     LOX_ASSERT(args.size() == _params.size());
 
-    auto env = _runtime->create<Environment>(_closure);
+    auto env = _runtime->createEnvironment(_closure);
     for (size_t i = 0; i < _params.size(); i++) {
         env->define(_params[i].lexeme, args[i]);
     }

--- a/src/Runtime.cpp
+++ b/src/Runtime.cpp
@@ -15,16 +15,27 @@ namespace cloxx {
 
 Runtime::Runtime()
 {
-    _objectClass = createObjectClass(this);
     _listClass = createListClass(this);
 
     // Built-in classes - Object, Class, Function, Nil
     _gc.root()->define("List", _listClass);
 }
 
+std::shared_ptr<Environment> const& Runtime::root()
+{
+    return _gc.root();
+}
+
+void Runtime::collectGarbage()
+{
+    _gc.collect();
+}
+
 std::shared_ptr<LoxClass> const& Runtime::objectClass()
 {
-    LOX_ASSERT(_objectClass);
+    if (!_objectClass) {
+        _objectClass = createObjectClass(this);
+    }
     return _objectClass;
 }
 
@@ -77,16 +88,6 @@ std::shared_ptr<LoxObject> Runtime::toLoxString(std::string value)
     auto instance = _stringClass->call({});
     static_cast<LoxString*>(instance.get())->value = std::move(value);
     return instance;
-}
-
-std::shared_ptr<Environment> const& Runtime::root()
-{
-    return _gc.root();
-}
-
-void Runtime::collectGarbage()
-{
-    _gc.collect();
 }
 
 } // namespace cloxx

--- a/src/Runtime.cpp
+++ b/src/Runtime.cpp
@@ -21,6 +21,11 @@ Runtime::Runtime()
     _gc.root()->define("List", _listClass);
 }
 
+std::shared_ptr<Environment> Runtime::createEnvironment(std::shared_ptr<Environment> const& closure)
+{
+    return _gc.create<Environment>(closure);
+}
+
 std::shared_ptr<Environment> const& Runtime::root()
 {
     return _gc.root();

--- a/src/Runtime.hpp
+++ b/src/Runtime.hpp
@@ -17,6 +17,9 @@ public:
         return _gc.create<T>(std::forward<Args>(args)...);
     }
 
+    std::shared_ptr<Environment> const& root();
+    void collectGarbage();
+
     std::shared_ptr<LoxClass> const& objectClass();
     std::shared_ptr<LoxClass> const& functionClass();
 
@@ -25,10 +28,9 @@ public:
     std::shared_ptr<LoxObject> toLoxNumber(double value);
     std::shared_ptr<LoxObject> toLoxString(std::string value);
 
-    std::shared_ptr<Environment> const& root();
-    void collectGarbage();
-
 private:
+    GarbageCollector _gc;
+
     // Built-in classes
     std::shared_ptr<LoxClass> _objectClass;
     std::shared_ptr<LoxClass> _functionClass;
@@ -41,8 +43,6 @@ private:
     std::shared_ptr<LoxObject> _nil;
     std::shared_ptr<LoxObject> _true;
     std::shared_ptr<LoxObject> _false;
-
-    GarbageCollector _gc;
 };
 
 } // namespace cloxx

--- a/src/Runtime.hpp
+++ b/src/Runtime.hpp
@@ -14,8 +14,10 @@ public:
     template <typename T, typename... Args>
     std::shared_ptr<T> create(Args&&... args)
     {
-        return _gc.create<T>(std::forward<Args>(args)...);
+        return _gc.create<T>(this, std::forward<Args>(args)...);
     }
+
+    std::shared_ptr<Environment> createEnvironment(std::shared_ptr<Environment> const& closure);
 
     std::shared_ptr<Environment> const& root();
     void collectGarbage();


### PR DESCRIPTION
Inheriting from `LoxClass` is no good while from `LoxObject` is OK.
