### PR TITLE
Makefile as shortcuts to shell commends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: configure configure-debug ast cloxx test clean
+.DEFAULT_GOAL := build/cloxx
+
+configure:
+	@scripts/configure.sh
+
+configure-debug:
+	@scripts/configure.sh --debug
+
+ast:
+	@scripts/gen-ast.sh
+
+build/cloxx:
+	@scripts/build.sh
+
+test: build/cloxx
+	@tool/run-test.py
+
+clean:
+	@rm -rf build


### PR DESCRIPTION
Make shortcut mappings:

| target | command |
|-------|-----------|
|  (empty) | `scripts/build.sh` |
|  `ast`| `scripts/gen-ast.sh` |
| `configure` | `scripts/configure.sh` |
| `configure-debug` | `scripts/configure.sh --debug` |
| `test` | `tool/run-test.py` |
| `clean` | `rm -rf build` |